### PR TITLE
feat: 카카오 소셜 로그인 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,14 +22,14 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.h2database:h2'
 
 
 
@@ -47,6 +47,10 @@ dependencies {
 
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	//Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,21 @@ dependencies {
 	//Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// Spring Cloud
+	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.0")
+
+	// Spring Cloud Open Feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+	// Oauth2
+	implementation 'org.springframework.security:spring-security-oauth2-client'
+	implementation 'org.springframework.security:spring-security-oauth2-jose'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/api/pickle/PickleApplication.java
+++ b/src/main/java/com/api/pickle/PickleApplication.java
@@ -2,8 +2,10 @@ package com.api.pickle;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PickleApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/api/pickle/domain/auth/api/AuthController.java
+++ b/src/main/java/com/api/pickle/domain/auth/api/AuthController.java
@@ -1,0 +1,26 @@
+package com.api.pickle.domain.auth.api;
+
+import com.api.pickle.domain.auth.application.AuthService;
+import com.api.pickle.domain.auth.dto.request.AuthCodeRequest;
+import com.api.pickle.domain.auth.dto.response.TokenPairResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "인증 API", description = "인증 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @Operation(summary = "회원가입 및 로그인", description = "회원가입 및 로그인을 진행합니다.")
+    @PostMapping("/login")
+    public TokenPairResponse memberOauthLogin(@RequestBody AuthCodeRequest request){
+        return authService.socialLogin(request.getCode());
+    }
+}

--- a/src/main/java/com/api/pickle/domain/auth/application/AuthService.java
+++ b/src/main/java/com/api/pickle/domain/auth/application/AuthService.java
@@ -1,0 +1,68 @@
+package com.api.pickle.domain.auth.application;
+
+import com.api.pickle.domain.auth.dto.response.KakaoTokenResponse;
+import com.api.pickle.domain.auth.dto.response.TokenPairResponse;
+import com.api.pickle.domain.member.dao.MemberRepository;
+import com.api.pickle.domain.member.domain.Member;
+import com.api.pickle.domain.member.domain.MemberRole;
+import com.api.pickle.domain.member.domain.OauthInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+    private final KakaoService kakaoService;
+    private final IdTokenVerifier idTokenVerifier;
+    private final MemberRepository memberRepository;
+    private final JwtTokenService jwtTokenService;
+
+    public TokenPairResponse socialLogin(String authCode){
+        KakaoTokenResponse response = kakaoService.getIdToken(authCode);
+        OidcUser oidcUser = idTokenVerifier.getOidcUser(response.getId_token());
+        OauthInfo oauthInfo = OauthInfo.from(oidcUser);
+
+        Member member = getMemberByOidcInfo(oidcUser, oauthInfo);
+        setAuthenticationToken(member.getId(), member.getRole());
+        return getLoginResponse(member);
+    }
+
+    public void setAuthenticationToken(Long memberId, MemberRole role) {
+        UserDetails userDetails =
+                User.withUsername(memberId.toString())
+                        .authorities(role.toString())
+                        .password("")
+                        .build();
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private TokenPairResponse getLoginResponse(Member member) {
+        String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
+        String refreshToken = jwtTokenService.createRefreshToken(member.getId());
+        return new TokenPairResponse(accessToken, refreshToken);
+    }
+
+    private String getUserSocialName(OidcUser oidcUser) {
+        return oidcUser.getClaim("nickname");
+    }
+
+    private Member getMemberByOidcInfo(OidcUser oidcUser, OauthInfo oauthInfo) {
+        return memberRepository
+                .findByOauthInfo(oauthInfo)
+                .orElseGet(() -> saveMember(oauthInfo, getUserSocialName(oidcUser)));
+    }
+
+    private Member saveMember(OauthInfo oauthInfo, String nickname) {
+        return memberRepository.save(Member.createNormalMember(oauthInfo, nickname));
+    }
+}

--- a/src/main/java/com/api/pickle/domain/auth/application/IdTokenVerifier.java
+++ b/src/main/java/com/api/pickle/domain/auth/application/IdTokenVerifier.java
@@ -1,0 +1,67 @@
+package com.api.pickle.domain.auth.application;
+
+import com.api.pickle.global.common.constants.SecurityConstants;
+import com.api.pickle.global.error.exception.CustomException;
+import com.api.pickle.global.error.exception.ErrorCode;
+import com.api.pickle.infra.config.oauth.KakaoProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class IdTokenVerifier {
+    private final KakaoProperties properties;
+    private final JwtDecoder jwtDecoder = buildDecoder();
+
+    public OidcUser getOidcUser(String idToken) {
+        Jwt jwt = jwtDecoder.decode(idToken);
+        OidcIdToken oidcIdToken =
+                new OidcIdToken(idToken, jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
+
+        validateIssuer(oidcIdToken);
+        validateExpired(oidcIdToken);
+        validateAudience(oidcIdToken);
+
+        List<GrantedAuthority> authorities =
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_NONE"));
+        return new DefaultOidcUser(authorities, oidcIdToken);
+    }
+
+    private void validateExpired(OidcIdToken oidcIdToken) {
+        Instant expiration = oidcIdToken.getExpiresAt();
+        if (expiration.isBefore(Instant.now())) {
+            throw new CustomException(ErrorCode.EXPIRED_JWT_TOKEN);
+        }
+    }
+
+    private void validateAudience(OidcIdToken oidcIdToken) {
+        String clientId = oidcIdToken.getAudience().get(0);
+        if (!properties.getId().equals(clientId)) {
+            throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateIssuer(OidcIdToken oidcIdToken) {
+        String issuer = oidcIdToken.getIssuer().toString();
+        if (!SecurityConstants.KAKAO_ISSUER.equals(issuer)) {
+            throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private JwtDecoder buildDecoder(){
+        String jwkUrl = SecurityConstants.KAKAO_JWK_SET_URL;
+        return NimbusJwtDecoder.withJwkSetUri(jwkUrl).build();
+    }
+}

--- a/src/main/java/com/api/pickle/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/api/pickle/domain/auth/application/JwtTokenService.java
@@ -1,0 +1,26 @@
+package com.api.pickle.domain.auth.application;
+
+import com.api.pickle.domain.auth.dao.RefreshTokenRepository;
+import com.api.pickle.domain.auth.domain.RefreshToken;
+import com.api.pickle.domain.member.domain.MemberRole;
+import com.api.pickle.global.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String createAccessToken(Long memberId, MemberRole role) {
+        return jwtUtil.generateAccessToken(memberId, role);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        String token = jwtUtil.generateRefreshToken(memberId);
+        RefreshToken refreshToken = RefreshToken.builder().memberId(memberId).token(token).build();
+        refreshTokenRepository.save(refreshToken);
+        return token;
+    }
+}

--- a/src/main/java/com/api/pickle/domain/auth/application/KakaoService.java
+++ b/src/main/java/com/api/pickle/domain/auth/application/KakaoService.java
@@ -1,0 +1,19 @@
+package com.api.pickle.domain.auth.application;
+
+import com.api.pickle.domain.auth.dto.request.KakaoTokenRequest;
+import com.api.pickle.domain.auth.dto.response.KakaoTokenResponse;
+import com.api.pickle.infra.config.feign.KakaoLoginClient;
+import com.api.pickle.infra.config.oauth.KakaoProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+    private final KakaoLoginClient kakaoLoginClient;
+    private final KakaoProperties properties;
+
+    public KakaoTokenResponse getIdToken(String code){
+        return kakaoLoginClient.getToken(KakaoTokenRequest.newInstance(properties, code).toString());
+    }
+}

--- a/src/main/java/com/api/pickle/domain/auth/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/api/pickle/domain/auth/dao/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.api.pickle.domain.auth.dao;
+
+import com.api.pickle.domain.auth.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {}

--- a/src/main/java/com/api/pickle/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/api/pickle/domain/auth/domain/RefreshToken.java
@@ -1,0 +1,24 @@
+package com.api.pickle.domain.auth.domain;
+
+import com.api.pickle.domain.common.model.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken extends BaseTimeEntity {
+    @Id
+    private Long memberId;
+
+    private String token;
+
+    @Builder
+    public RefreshToken(Long memberId, String token) {
+        this.memberId = memberId;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/api/pickle/domain/auth/dto/request/AuthCodeRequest.java
+++ b/src/main/java/com/api/pickle/domain/auth/dto/request/AuthCodeRequest.java
@@ -1,0 +1,14 @@
+package com.api.pickle.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthCodeRequest {
+    @Schema(description = "카카오 로그인을 통한 인증코드")
+    private String code;
+}

--- a/src/main/java/com/api/pickle/domain/auth/dto/request/KakaoTokenRequest.java
+++ b/src/main/java/com/api/pickle/domain/auth/dto/request/KakaoTokenRequest.java
@@ -1,0 +1,41 @@
+package com.api.pickle.domain.auth.dto.request;
+
+import com.api.pickle.infra.config.oauth.KakaoProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class KakaoTokenRequest {
+
+    private String code;
+    private String clientId;
+    private String redirectUri;
+    private String clientSecret;
+    private String grantType;
+
+    public static KakaoTokenRequest newInstance(KakaoProperties properties, String code) {
+        return KakaoTokenRequest.builder()
+                .code(code)
+                .clientId(properties.getId())
+                .clientSecret(properties.getSecret())
+                .redirectUri(properties.getRedirectUri())
+                .grantType(properties.getGrantType())
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "grant_type=" + grantType +
+                "&client_id=" + clientId +
+                "&redirect_uri=" + redirectUri +
+                "&code=" + code +
+                "&client_secret=" + clientSecret;
+    }
+
+
+}

--- a/src/main/java/com/api/pickle/domain/auth/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/api/pickle/domain/auth/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,18 @@
+package com.api.pickle.domain.auth.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+    private String token_type;
+    private String access_token;
+    private String expires_in;
+    private String refresh_token;
+    private String refresh_token_expires_in;
+    private String scope;
+    private String id_token;
+}

--- a/src/main/java/com/api/pickle/domain/auth/dto/response/TokenPairResponse.java
+++ b/src/main/java/com/api/pickle/domain/auth/dto/response/TokenPairResponse.java
@@ -1,0 +1,14 @@
+package com.api.pickle.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenPairResponse {
+    @Schema(description = "엑세스 토큰")
+    private String accessToken;
+    @Schema(description = "리프레시 토큰")
+    private String refreshToken;
+}

--- a/src/main/java/com/api/pickle/domain/imagetag/domain/ImageTag.java
+++ b/src/main/java/com/api/pickle/domain/imagetag/domain/ImageTag.java
@@ -15,7 +15,7 @@ import static jakarta.persistence.FetchType.LAZY;
 public class ImageTag {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "image_tag_id")
     private Long id;
 

--- a/src/main/java/com/api/pickle/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/api/pickle/domain/member/dao/MemberRepository.java
@@ -1,7 +1,11 @@
 package com.api.pickle.domain.member.dao;
 
 import com.api.pickle.domain.member.domain.Member;
+import com.api.pickle.domain.member.domain.OauthInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
 }

--- a/src/main/java/com/api/pickle/domain/member/domain/Member.java
+++ b/src/main/java/com/api/pickle/domain/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.api.pickle.domain.member.domain;
 import com.api.pickle.domain.common.model.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,4 +18,30 @@ public class Member extends BaseTimeEntity {
     private Long id;
 
     private String nickname;
+
+    @Embedded private OauthInfo oauthInfo;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    @Builder
+    private Member(String nickname, OauthInfo oauthInfo, MemberRole role, MemberStatus status) {
+        this.nickname = nickname;
+        this.oauthInfo = oauthInfo;
+        this.role = role;
+        this.status = status;
+    }
+
+    public static Member createNormalMember(OauthInfo oauthInfo, String nickname) {
+        return Member.builder()
+                .nickname(nickname)
+                .role(MemberRole.USER)
+                .status(MemberStatus.NORMAL)
+                .oauthInfo(oauthInfo)
+                .build();
+    }
 }

--- a/src/main/java/com/api/pickle/domain/member/domain/MemberRole.java
+++ b/src/main/java/com/api/pickle/domain/member/domain/MemberRole.java
@@ -1,0 +1,12 @@
+package com.api.pickle.domain.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRole {
+    USER("ROLE_USER");
+
+    private final String value;
+}

--- a/src/main/java/com/api/pickle/domain/member/domain/MemberStatus.java
+++ b/src/main/java/com/api/pickle/domain/member/domain/MemberStatus.java
@@ -1,0 +1,14 @@
+package com.api.pickle.domain.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberStatus {
+    NORMAL("NORMAL"),
+    DELETED("DELETED"),
+    FORBIDDEN("FORBIDDEN");
+
+    private final String value;
+}

--- a/src/main/java/com/api/pickle/domain/member/domain/OauthInfo.java
+++ b/src/main/java/com/api/pickle/domain/member/domain/OauthInfo.java
@@ -1,0 +1,28 @@
+package com.api.pickle.domain.member.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class OauthInfo {
+    private String oauthId;
+    private String profile;
+
+    @Builder
+    public OauthInfo(String oauthId, String oauthProvider, String oauthEmail, String profile) {
+        this.oauthId = oauthId;
+        this.profile = profile;
+    }
+
+    public static OauthInfo from(OidcUser user) {
+        return OauthInfo.builder()
+                .oauthId(user.getSubject())
+                .profile(user.getAttributes().get("picture").toString())
+                .build();
+    }
+}

--- a/src/main/java/com/api/pickle/global/common/constants/SecurityConstants.java
+++ b/src/main/java/com/api/pickle/global/common/constants/SecurityConstants.java
@@ -1,0 +1,13 @@
+package com.api.pickle.global.common.constants;
+
+
+public final class SecurityConstants {
+    public static final String TOKEN_ROLE_NAME = "role";
+
+    public static final String KAKAO_LOGIN_URL = "https://kauth.kakao.com";
+    public static final String KAKAO_LOGIN_ENDPOINT = "/oauth/token";
+
+    public static final String KAKAO_ISSUER = "https://kauth.kakao.com";
+    public static final String KAKAO_JWK_SET_URL = "https://kauth.kakao.com/.well-known/jwks.json";
+
+}

--- a/src/main/java/com/api/pickle/global/common/response/GlobalResponse.java
+++ b/src/main/java/com/api/pickle/global/common/response/GlobalResponse.java
@@ -1,4 +1,4 @@
-package com.api.pickle.global.common;
+package com.api.pickle.global.common.response;
 
 import com.api.pickle.global.error.ErrorResponse;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/api/pickle/global/common/response/GlobalResponseAdvice.java
+++ b/src/main/java/com/api/pickle/global/common/response/GlobalResponseAdvice.java
@@ -1,4 +1,4 @@
-package com.api.pickle.global.common;
+package com.api.pickle.global.common.response;
 
 import jakarta.servlet.http.HttpServletResponse;
 

--- a/src/main/java/com/api/pickle/global/config/feign/KakaoFeignConfig.java
+++ b/src/main/java/com/api/pickle/global/config/feign/KakaoFeignConfig.java
@@ -1,0 +1,15 @@
+package com.api.pickle.global.config.feign;
+
+import feign.RequestInterceptor;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.api.pickle.infra.config.feign")
+public class KakaoFeignConfig {
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return template -> template.header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+    }
+}

--- a/src/main/java/com/api/pickle/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/api/pickle/global/config/security/WebSecurityConfig.java
@@ -1,0 +1,50 @@
+package com.api.pickle.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception{
+        defaultFilterChain(http);
+        http.authorizeHttpRequests((requests) -> requests.requestMatchers("**").permitAll());
+        return http.build();
+    }
+
+    private void defaultFilterChain(HttpSecurity http) throws Exception{
+        http.httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                );
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(){
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/com/api/pickle/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/api/pickle/global/config/swagger/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.api.pickle.global.config;
+package com.api.pickle.global.config.swagger;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/com/api/pickle/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/api/pickle/global/error/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.api.pickle.global.error;
 
-import com.api.pickle.global.common.GlobalResponse;
+import com.api.pickle.global.common.response.GlobalResponse;
 import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
@@ -9,6 +9,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     SAMPLE_ERROR(HttpStatus.BAD_REQUEST, "Sample Error Message"),
+
+    ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/api/pickle/global/util/JwtUtil.java
+++ b/src/main/java/com/api/pickle/global/util/JwtUtil.java
@@ -1,0 +1,63 @@
+package com.api.pickle.global.util;
+
+import com.api.pickle.domain.member.domain.MemberRole;
+import com.api.pickle.infra.config.jwt.JwtProperties;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+import static com.api.pickle.global.common.constants.SecurityConstants.TOKEN_ROLE_NAME;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+    private final JwtProperties jwtProperties;
+
+    public String generateAccessToken(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    private String buildAccessToken(
+            Long memberId, MemberRole memberRole, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.getIssuer())
+                .setSubject(memberId.toString())
+                .claim(TOKEN_ROLE_NAME, memberRole.name())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getAccessTokenKey())
+                .compact();
+    }
+
+    private String buildRefreshToken(Long memberId, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.getIssuer())
+                .setSubject(memberId.toString())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRefreshTokenKey())
+                .compact();
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getAccessTokenSecret().getBytes());
+    }
+
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getRefreshTokenSecret().getBytes());
+    }
+}

--- a/src/main/java/com/api/pickle/infra/config/feign/KakaoLoginClient.java
+++ b/src/main/java/com/api/pickle/infra/config/feign/KakaoLoginClient.java
@@ -1,0 +1,18 @@
+package com.api.pickle.infra.config.feign;
+
+import com.api.pickle.domain.auth.dto.response.KakaoTokenResponse;
+import com.api.pickle.global.common.constants.SecurityConstants;
+import com.api.pickle.global.config.feign.KakaoFeignConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+        name = "kakaoLoginClient",
+        url = SecurityConstants.KAKAO_LOGIN_URL,
+        configuration = KakaoFeignConfig.class)
+public interface KakaoLoginClient {
+    @PostMapping(value = SecurityConstants.KAKAO_LOGIN_ENDPOINT)
+    KakaoTokenResponse getToken(@RequestBody String KakaoTokenRequest);
+}
+

--- a/src/main/java/com/api/pickle/infra/config/jwt/JwtProperties.java
+++ b/src/main/java/com/api/pickle/infra/config/jwt/JwtProperties.java
@@ -1,0 +1,24 @@
+package com.api.pickle.infra.config.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Setter
+public class JwtProperties {
+    private String accessTokenSecret;
+    private String refreshTokenSecret;
+    private Long accessTokenExpirationTime;
+    private Long refreshTokenExpirationTime;
+    private String issuer;
+
+    public Long accessTokenExpirationMilliTime() {
+        return accessTokenExpirationTime * 1000;
+    }
+
+    public Long refreshTokenExpirationMilliTime() {
+        return refreshTokenExpirationTime * 1000;
+    }
+}

--- a/src/main/java/com/api/pickle/infra/config/oauth/KakaoProperties.java
+++ b/src/main/java/com/api/pickle/infra/config/oauth/KakaoProperties.java
@@ -1,0 +1,15 @@
+package com.api.pickle.infra.config.oauth;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao.client")
+@Getter
+@Setter
+public class KakaoProperties {
+    private String id;
+    private String secret;
+    private String redirectUri;
+    private String grantType;
+}

--- a/src/main/java/com/api/pickle/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/api/pickle/infra/config/properties/PropertiesConfig.java
@@ -1,0 +1,10 @@
+package com.api.pickle.infra.config.properties;
+
+import com.api.pickle.infra.config.jwt.JwtProperties;
+import com.api.pickle.infra.config.oauth.KakaoProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties({KakaoProperties.class, JwtProperties.class})
+@Configuration
+public class PropertiesConfig {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,4 +13,6 @@ spring:
         format_sql: true
 
   profiles:
-    include: s3
+    include:
+      - s3
+      - security


### PR DESCRIPTION
## 📌 Issue Number

- close #3 

## 🪐 작업 내용

- 카카오 소셜 로그인 api 구현

## ✅ PR 상세 내용

- `feign`을 통하여 인증 코드를 통한 `id token` 값을 받아옴
- 받아온 `id token` 값을 이용하여 사용자 정보 저장
- `jwt`를 이용한 `accessToken` 및 `refreshToken` 발급 후 응답 본문으로 전송
- 리액트 네이티브를 이용하여 쿠키 형태가 아닌 응답 본문 형태로 토큰 전송 


## 📸 스크린샷(선택)

- X

## ❌ 애로 사항

- `swagger` 적용시 공통 응답 형식이 적용되지 않는 문제 발생 

## 📚 Reference

- X
