### PR TITLE
feat : 토큰 검증 로직 구현

### DIFF
--- a/src/main/java/com/api/pickle/domain/auth/api/AuthController.java
+++ b/src/main/java/com/api/pickle/domain/auth/api/AuthController.java
@@ -2,6 +2,7 @@ package com.api.pickle.domain.auth.api;
 
 import com.api.pickle.domain.auth.application.AuthService;
 import com.api.pickle.domain.auth.dto.request.AuthCodeRequest;
+import com.api.pickle.domain.auth.dto.request.RefreshRequest;
 import com.api.pickle.domain.auth.dto.response.TokenPairResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,5 +23,11 @@ public class AuthController {
     @PostMapping("/login")
     public TokenPairResponse memberOauthLogin(@RequestBody AuthCodeRequest request){
         return authService.socialLogin(request.getCode());
+    }
+
+    @Operation(summary = "토큰 재발급", description = "엑세스 토큰 및 리프테시 토큰을 모두 재발급합니다.")
+    @PostMapping("/refresh")
+    public TokenPairResponse refreshToken(@RequestBody RefreshRequest request){
+        return authService.refreshToken(request);
     }
 }

--- a/src/main/java/com/api/pickle/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/api/pickle/domain/auth/application/JwtTokenService.java
@@ -2,11 +2,23 @@ package com.api.pickle.domain.auth.application;
 
 import com.api.pickle.domain.auth.dao.RefreshTokenRepository;
 import com.api.pickle.domain.auth.domain.RefreshToken;
+import com.api.pickle.domain.auth.dto.AccessTokenDto;
+import com.api.pickle.domain.auth.dto.RefreshTokenDto;
+import com.api.pickle.domain.member.domain.Member;
 import com.api.pickle.domain.member.domain.MemberRole;
+import com.api.pickle.global.error.exception.CustomException;
+import com.api.pickle.global.error.exception.ErrorCode;
 import com.api.pickle.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+
+@Transactional
 @Service
 @RequiredArgsConstructor
 public class JwtTokenService {
@@ -22,5 +34,42 @@ public class JwtTokenService {
         RefreshToken refreshToken = RefreshToken.builder().memberId(memberId).token(token).build();
         refreshTokenRepository.save(refreshToken);
         return token;
+    }
+
+    public void setAuthenticationToken(Long memberId, MemberRole role) {
+        UserDetails userDetails =
+                User.withUsername(memberId.toString())
+                        .authorities(role.toString())
+                        .password("")
+                        .build();
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+        try {
+            return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto validateRefreshToken(String refreshToken){
+        return jwtUtil.parseRefreshToken(refreshToken);
+    }
+
+    public RefreshTokenDto refreshRefreshToken(RefreshTokenDto oldRefreshTokenDto){
+        RefreshToken refreshToken = refreshTokenRepository.findById(oldRefreshTokenDto.getMemberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MISSING_JWT_TOKEN));
+        RefreshTokenDto refreshTokenDto = jwtUtil.generateRefreshTokenDto(refreshToken.getMemberId());
+        refreshToken.updateRefreshToken(refreshTokenDto.getToken());
+        refreshTokenRepository.save(refreshToken);
+        return refreshTokenDto;
+    }
+
+    public AccessTokenDto refreshAccessToken(Member member){
+        return jwtUtil.generateAccessTokenDto(member.getId(), member.getRole());
     }
 }

--- a/src/main/java/com/api/pickle/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/api/pickle/domain/auth/domain/RefreshToken.java
@@ -21,4 +21,8 @@ public class RefreshToken extends BaseTimeEntity {
         this.memberId = memberId;
         this.token = token;
     }
+
+    public void updateRefreshToken(String newToken){
+        this.token = newToken;
+    }
 }

--- a/src/main/java/com/api/pickle/domain/auth/dto/AccessTokenDto.java
+++ b/src/main/java/com/api/pickle/domain/auth/dto/AccessTokenDto.java
@@ -1,0 +1,13 @@
+package com.api.pickle.domain.auth.dto;
+
+import com.api.pickle.domain.member.domain.MemberRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AccessTokenDto {
+    private Long memberId;
+    private MemberRole memberRole;
+    private String token;
+}

--- a/src/main/java/com/api/pickle/domain/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/com/api/pickle/domain/auth/dto/RefreshTokenDto.java
@@ -1,0 +1,13 @@
+package com.api.pickle.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class RefreshTokenDto {
+    private Long memberId;
+    private String token;
+    private Long expiredTime;
+}
+

--- a/src/main/java/com/api/pickle/domain/auth/dto/request/RefreshRequest.java
+++ b/src/main/java/com/api/pickle/domain/auth/dto/request/RefreshRequest.java
@@ -1,0 +1,16 @@
+package com.api.pickle.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class RefreshRequest {
+    @Schema(description = "갱신을 위한 리프레시 토큰")
+    private String refreshToken;
+}

--- a/src/main/java/com/api/pickle/global/common/constants/SecurityConstants.java
+++ b/src/main/java/com/api/pickle/global/common/constants/SecurityConstants.java
@@ -3,6 +3,7 @@ package com.api.pickle.global.common.constants;
 
 public final class SecurityConstants {
     public static final String TOKEN_ROLE_NAME = "role";
+    public static final String TOKEN_PREFIX = "Bearer ";
 
     public static final String KAKAO_LOGIN_URL = "https://kauth.kakao.com";
     public static final String KAKAO_LOGIN_ENDPOINT = "/oauth/token";

--- a/src/main/java/com/api/pickle/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/api/pickle/global/config/security/WebSecurityConfig.java
@@ -1,5 +1,7 @@
 package com.api.pickle.global.config.security;
 
+import com.api.pickle.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -7,20 +9,25 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception{
         defaultFilterChain(http);
-        http.authorizeHttpRequests((requests) -> requests.requestMatchers("**").permitAll());
+        http.authorizeHttpRequests((requests) -> requests.requestMatchers("**").permitAll())
+            .addFilterBefore(
+                    jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
@@ -12,6 +12,12 @@ public enum ErrorCode {
 
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    MISSING_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 정보가 존재하지 않습니다."),
+
+    AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보를 찾을 수 없습니다."),
+
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/api/pickle/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/api/pickle/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.api.pickle.global.security;
+
+import com.api.pickle.domain.auth.application.JwtTokenService;
+import com.api.pickle.domain.auth.dto.AccessTokenDto;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.api.pickle.global.common.constants.SecurityConstants.TOKEN_PREFIX;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenService jwtTokenService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
+
+        if (accessTokenHeaderValue != null){
+            AccessTokenDto accessTokenDto = jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
+            if (accessTokenDto != null){
+                jwtTokenService.setAuthenticationToken(accessTokenDto.getMemberId(), accessTokenDto.getMemberRole());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractAccessTokenFromHeader(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith(TOKEN_PREFIX)){
+            return header.replace(TOKEN_PREFIX, "");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/api/pickle/global/util/JwtUtil.java
+++ b/src/main/java/com/api/pickle/global/util/JwtUtil.java
@@ -1,7 +1,12 @@
 package com.api.pickle.global.util;
 
+import com.api.pickle.domain.auth.dto.AccessTokenDto;
+import com.api.pickle.domain.auth.dto.RefreshTokenDto;
 import com.api.pickle.domain.member.domain.MemberRole;
 import com.api.pickle.infra.config.jwt.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
@@ -24,11 +29,28 @@ public class JwtUtil {
         return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
     }
 
+    public AccessTokenDto generateAccessTokenDto(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String tokenValue = buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+        return new AccessTokenDto(memberId, memberRole, tokenValue);
+    }
+
     public String generateRefreshToken(Long memberId) {
         Date issuedAt = new Date();
         Date expiredAt =
                 new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
         return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    public RefreshTokenDto generateRefreshTokenDto(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        String tokenValue = buildRefreshToken(memberId, issuedAt, expiredAt);
+        return new RefreshTokenDto(
+                memberId, tokenValue, jwtProperties.getRefreshTokenExpirationTime());
     }
 
     private String buildAccessToken(
@@ -59,5 +81,45 @@ public class JwtUtil {
 
     private Key getRefreshTokenKey() {
         return Keys.hmacShaKeyFor(jwtProperties.getRefreshTokenSecret().getBytes());
+    }
+
+    public AccessTokenDto parseAccessToken(String token) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(token, getAccessTokenKey());
+
+            return new AccessTokenDto(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    MemberRole.valueOf(claims.getBody().get(TOKEN_ROLE_NAME, String.class)),
+                    token);
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰인 경우에만 ExpiredJwtException 발생
+            throw e;
+        } catch (Exception e) {
+            // 토큰 파싱에 실패하면 null 반환
+            return null;
+        }
+    }
+
+    public RefreshTokenDto parseRefreshToken(String token) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(token, getRefreshTokenKey());
+
+            return new RefreshTokenDto(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    token,
+                    jwtProperties.getRefreshTokenExpirationTime());
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Jws<Claims> getClaims(String token, Key key) {
+        return Jwts.parserBuilder()
+                .requireIssuer(jwtProperties.getIssuer())
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
     }
 }

--- a/src/main/java/com/api/pickle/global/util/MemberUtil.java
+++ b/src/main/java/com/api/pickle/global/util/MemberUtil.java
@@ -1,0 +1,23 @@
+package com.api.pickle.global.util;
+
+import com.api.pickle.domain.member.dao.MemberRepository;
+import com.api.pickle.domain.member.domain.Member;
+import com.api.pickle.global.error.exception.CustomException;
+import com.api.pickle.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberUtil {
+
+    private final SecurityUtil securityUtil;
+    private final MemberRepository memberRepository;
+
+    public Member getCurrentMember() {
+        return memberRepository
+                .findById(securityUtil.getCurrentMemberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}
+

--- a/src/main/java/com/api/pickle/global/util/SecurityUtil.java
+++ b/src/main/java/com/api/pickle/global/util/SecurityUtil.java
@@ -1,0 +1,20 @@
+package com.api.pickle.global.util;
+
+import com.api.pickle.global.error.exception.CustomException;
+import com.api.pickle.global.error.exception.ErrorCode;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityUtil {
+
+    public Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.AUTH_NOT_FOUND);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Issue Number

- close #26 

## 🪐 작업 내용

- 토큰 검증 로직, 갱신 로직 및 요청자 조회 기능 구현

## ✅ PR 상세 내용

- 검증 로직을 필터로 구현
- 엑세스 토큰 만료시 예외를 반환하고 새로운 요청을 통해 토큰들이 갱신되도록 조정
- `securitycontextholder`를 이용하여 현재 요청자의 정보 조회 메소드 구현

## 📸 스크린샷(선택)

- X

## ❌ 애로 사항

- X

## 📚 Reference

- X
