### PR TITLE
feat : swagger jwt 인증 설정 추가

### DIFF
--- a/src/main/java/com/api/pickle/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/api/pickle/global/config/swagger/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.api.pickle.global.config.swagger;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,7 +15,8 @@ public class SwaggerConfig {
     public OpenAPI pickleApi() {
         return new OpenAPI()
                 .info(apiInfo())
-                .components(new Components());
+                .components(authSetting())
+                .addSecurityItem(securityRequirement());
     }
 
     private Info apiInfo() {
@@ -21,5 +24,23 @@ public class SwaggerConfig {
                 .title("Pickle API")
                 .description("Pickle API 명세서")
                 .version("1.0.0");
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList("accessToken");
+        return securityRequirement;
     }
 }


### PR DESCRIPTION
## 📌 Issue Number

- close #29 

## 🪐 작업 내용

- swagger에 `jwt` 인증 설정 추가

## ✅ PR 상세 내용

- `Authorization` 헤더에 엑세스토큰값을 추가하여 저장하면 다른 테스트 시 자동으로 헤더에 포함되도록 설정

## 📸 스크린샷(선택)

![image](https://github.com/Pickle-Tave/Pickle-BE/assets/154600308/e87dd7f9-7b47-404a-9a24-b24cdc7d966b)

## ❌ 애로 사항

- X

## 📚 Reference

- https://velog.io/@u-nij/Spring-Boot-Swagger-3.0-%EC%84%A4%EC%A0%95-JWT-%EC%9D%B8%EC%A6%9D-%EC%84%A4%EC%A0%95-Profile%EB%A1%9C-%ED%99%98%EA%B2%BD%EB%B3%84-%EC%84%A4%EC%A0%95
