### PR TITLE
chore: application.yml 환경 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Mysql
+	implementation 'mysql:mysql-connector-java:8.0.33'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  datasource:
+    url: ${H2_DATASOURCE_URL}
+    username: ${H2_USERNAME}
+    password: ${H2_PASSWORD}
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: jdbc:mysql://${MYSQL_HOST}:3306/${MYSQL_DB_NAME}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,10 @@
 spring:
-  datasource:
-    url: ${H2_DATASOURCE_URL}
-    username: ${H2_DATASOURCE_USERNAME}
-    password: ${H2_DATASOURCE_PASSWORD}
-    driver-class-name: org.h2.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        format_sql: true
-
   profiles:
-    include:
-      - s3
-      - security
+    active: dev
+    group:
+      dev:
+        - s3
+        - security
+      prod:
+        - s3
+        - security


### PR DESCRIPTION
## 📌 Issue Number

- close #33 

## 🪐 작업 내용

- 개발 환경과 운영 환경 분리
- RDS (Mysql) 설정
- 운영 환경에서 EC2 수동 배포 

## ✅ PR 상세 내용

- 개발 환경과 운영 환경에서 다른 DB를 사용하여 개발 과정에서의 데이터 변경이 운영 환경에 영향을 미치지 않도록 하였습니다. 개발 환경은 H2 DB를 사용하였고, 운영 환경은 RDS Mysql를 사용하였습니다.
- 운영 환경에서 EC2에 수동으로 1차 배포를 완료하였습니다. 이후 배포 자동화 환경 구축 예정입니다.

## 📸 스크린샷(선택)

- X

## ❌ 애로 사항

- X

## 📚 Reference

- https://hoestory.tistory.com/66
- https://cjlee.io/post/tech/spring/2022-08-13-spring-environment-seperation/
