### PR TITLE
feat: 로그아웃 로직 구현

### DIFF
--- a/src/main/java/com/api/pickle/domain/member/api/MemberController.java
+++ b/src/main/java/com/api/pickle/domain/member/api/MemberController.java
@@ -1,12 +1,26 @@
 package com.api.pickle.domain.member.api;
 
 import com.api.pickle.domain.member.application.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "유저 API", description = "사용자 관련 API입니다.")
+@RequestMapping("/members")
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
+
+    @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> memberLogout(){
+        memberService.memberLogout();
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/api/pickle/domain/member/application/MemberService.java
+++ b/src/main/java/com/api/pickle/domain/member/application/MemberService.java
@@ -1,6 +1,9 @@
 package com.api.pickle.domain.member.application;
 
+import com.api.pickle.domain.auth.dao.RefreshTokenRepository;
 import com.api.pickle.domain.member.dao.MemberRepository;
+import com.api.pickle.domain.member.domain.Member;
+import com.api.pickle.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,4 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberUtil memberUtil;
+
+    public void memberLogout(){
+        final Member currentMember = memberUtil.getCurrentMember();
+        refreshTokenRepository.findById(currentMember.getId())
+                .ifPresent(refreshTokenRepository::delete);
+    }
 }


### PR DESCRIPTION
## 📌 Issue Number

- close #37 

## 🪐 작업 내용

- 로그아웃 api 요청시 진행되는 로그아웃 로직 구현

## ✅ PR 상세 내용

- 헤더에 `access token`을 가지고 로그아웃 요청 시 요청 사용자의 `refresh token`을 삭제하고 `200 OK` 반환

## ❌ 애로 사항

- X

## 📚 Reference

- X
