### PR TITLE
feat: 회원탈퇴 로직 구현

### DIFF
--- a/src/main/java/com/api/pickle/domain/auth/application/AuthService.java
+++ b/src/main/java/com/api/pickle/domain/auth/application/AuthService.java
@@ -7,6 +7,7 @@ import com.api.pickle.domain.auth.dto.response.KakaoTokenResponse;
 import com.api.pickle.domain.auth.dto.response.TokenPairResponse;
 import com.api.pickle.domain.member.dao.MemberRepository;
 import com.api.pickle.domain.member.domain.Member;
+import com.api.pickle.domain.member.domain.MemberStatus;
 import com.api.pickle.domain.member.domain.OauthInfo;
 import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
@@ -61,9 +62,13 @@ public class AuthService {
     }
 
     private Member getMemberByOidcInfo(OidcUser oidcUser, OauthInfo oauthInfo) {
-        return memberRepository
+        Member member =  memberRepository
                 .findByOauthInfo(oauthInfo)
                 .orElseGet(() -> saveMember(oauthInfo, getUserSocialName(oidcUser)));
+        if (member.getStatus() == MemberStatus.DELETED){
+            member.reEnroll();
+        }
+        return member;
     }
 
     private Member saveMember(OauthInfo oauthInfo, String nickname) {

--- a/src/main/java/com/api/pickle/domain/member/api/MemberController.java
+++ b/src/main/java/com/api/pickle/domain/member/api/MemberController.java
@@ -1,12 +1,26 @@
 package com.api.pickle.domain.member.api;
 
 import com.api.pickle.domain.member.application.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "유저 API", description = "사용자 관련 API입니다.")
+@RequestMapping("/members")
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
+
+    @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> memberLogout(){
+        memberService.memberLogout();
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/api/pickle/domain/member/api/MemberController.java
+++ b/src/main/java/com/api/pickle/domain/member/api/MemberController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +22,13 @@ public class MemberController {
     @PostMapping("/logout")
     public ResponseEntity<Void> memberLogout(){
         memberService.memberLogout();
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원탈퇴", description = "회원탈퇴를 진행합니다.")
+    @DeleteMapping("/withdrawal")
+    public ResponseEntity<Void> memberWithdrawal(){
+        memberService.memberWithdrawal();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/api/pickle/domain/member/application/MemberService.java
+++ b/src/main/java/com/api/pickle/domain/member/application/MemberService.java
@@ -22,4 +22,11 @@ public class MemberService {
         refreshTokenRepository.findById(currentMember.getId())
                 .ifPresent(refreshTokenRepository::delete);
     }
+
+    public void memberWithdrawal(){
+        final Member currentMember = memberUtil.getCurrentMember();
+        refreshTokenRepository.findById(currentMember.getId())
+                .ifPresent(refreshTokenRepository::delete);
+        currentMember.withdrawal();
+    }
 }

--- a/src/main/java/com/api/pickle/domain/member/application/MemberService.java
+++ b/src/main/java/com/api/pickle/domain/member/application/MemberService.java
@@ -1,6 +1,9 @@
 package com.api.pickle.domain.member.application;
 
+import com.api.pickle.domain.auth.dao.RefreshTokenRepository;
 import com.api.pickle.domain.member.dao.MemberRepository;
+import com.api.pickle.domain.member.domain.Member;
+import com.api.pickle.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,4 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberUtil memberUtil;
+
+    public void memberLogout(){
+        final Member currentMember = memberUtil.getCurrentMember();
+        refreshTokenRepository.findById(currentMember.getId())
+                .ifPresent(refreshTokenRepository::delete);
+    }
 }

--- a/src/main/java/com/api/pickle/domain/member/domain/Member.java
+++ b/src/main/java/com/api/pickle/domain/member/domain/Member.java
@@ -53,4 +53,8 @@ public class Member extends BaseTimeEntity {
         }
         this.status = MemberStatus.DELETED;
     }
+
+    public void reEnroll(){
+        this.status = MemberStatus.NORMAL;
+    }
 }

--- a/src/main/java/com/api/pickle/domain/member/domain/Member.java
+++ b/src/main/java/com/api/pickle/domain/member/domain/Member.java
@@ -1,6 +1,8 @@
 package com.api.pickle.domain.member.domain;
 
 import com.api.pickle.domain.common.model.BaseTimeEntity;
+import com.api.pickle.global.error.exception.CustomException;
+import com.api.pickle.global.error.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -43,5 +45,12 @@ public class Member extends BaseTimeEntity {
                 .status(MemberStatus.NORMAL)
                 .oauthInfo(oauthInfo)
                 .build();
+    }
+
+    public void withdrawal() {
+        if (this.status == MemberStatus.DELETED) {
+            throw new CustomException(ErrorCode.MEMBER_ALREADY_DELETED);
+        }
+        this.status = MemberStatus.DELETED;
     }
 }

--- a/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
+    MEMBER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
 
     ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 앨범을 찾을 수 없습니다"),
     ;

--- a/src/main/java/com/api/pickle/global/util/MemberUtil.java
+++ b/src/main/java/com/api/pickle/global/util/MemberUtil.java
@@ -2,6 +2,7 @@ package com.api.pickle.global.util;
 
 import com.api.pickle.domain.member.dao.MemberRepository;
 import com.api.pickle.domain.member.domain.Member;
+import com.api.pickle.domain.member.domain.MemberStatus;
 import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -15,9 +16,15 @@ public class MemberUtil {
     private final MemberRepository memberRepository;
 
     public Member getCurrentMember() {
-        return memberRepository
+        Member member = memberRepository
                 .findById(securityUtil.getCurrentMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getStatus() == MemberStatus.DELETED){
+            throw new CustomException(ErrorCode.MEMBER_ALREADY_DELETED);
+        }
+
+        return member;
     }
 }
 


### PR DESCRIPTION
## 📌 Issue Number

- close #38 

## 🪐 작업 내용

- 회원탈퇴 로직 구현

## ✅ PR 상세 내용

- 회원 탈퇴 시 `member`의 상태가 `DELETED`로 변환되도록 설정했습니다.
  - 회원 탈퇴 시 관련 모든 데이터를 삭제하는 것 보다 삭제 회원의 데이터 조회 시 보여지는 데이터가 설정되도록 구현했습니다. 
- 탈퇴 처리된 유저의 엑세스토큰으로 접근 시 예외가 발생하도록 설정했습니다. 

## ❌ 애로 사항

- X

## 📚 Reference

- X