### PR TITLE
feat: 앨범 생성 로직 구현 

### DIFF
--- a/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
+++ b/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
@@ -1,0 +1,29 @@
+package com.api.pickle.domain.album.api;
+
+
+import com.api.pickle.domain.album.application.AlbumService;
+import com.api.pickle.domain.album.dto.request.AlbumCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "앨범 API", description = "앨범 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/albums")
+public class AlbumController {
+    private final AlbumService albumService;
+
+    @Operation(summary = "앨범 생성", description = "앨범 생성을 진행합니다.")
+    @PostMapping("/create")
+    public ResponseEntity<Void> createAlbum(@RequestBody AlbumCreateRequest request){
+        albumService.createAlbum(request.getName());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
+++ b/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
@@ -1,0 +1,28 @@
+package com.api.pickle.domain.album.application;
+
+import com.api.pickle.domain.album.dao.AlbumRepository;
+import com.api.pickle.domain.album.domain.Album;
+import com.api.pickle.domain.member.domain.Member;
+import com.api.pickle.domain.participant.dao.ParticipantRepository;
+import com.api.pickle.domain.participant.domain.Participant;
+import com.api.pickle.global.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AlbumService {
+    private final AlbumRepository albumRepository;
+    private final ParticipantRepository participantRepository;
+    private final MemberUtil memberUtil;
+
+    public void createAlbum(String albumName){
+        Member currentMember = memberUtil.getCurrentMember();
+        Album newAlbum = Album.createPrivateAlbum(albumName);
+
+        albumRepository.save(newAlbum);
+        participantRepository.save(Participant.createParticipant(newAlbum, currentMember));
+    }
+}

--- a/src/main/java/com/api/pickle/domain/album/domain/Album.java
+++ b/src/main/java/com/api/pickle/domain/album/domain/Album.java
@@ -3,6 +3,7 @@ package com.api.pickle.domain.album.domain;
 import com.api.pickle.domain.common.model.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,4 +16,23 @@ public class Album extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "album_id")
     private Long id;
+
+    @Column(name = "album_name")
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private SharingStatus status;
+
+    @Builder
+    private Album (String name, SharingStatus status){
+        this.name = name;
+        this.status = status;
+    }
+
+    public static Album createPrivateAlbum(String name){
+        return Album.builder()
+                .name(name)
+                .status(SharingStatus.PRIVATE)
+                .build();
+    }
 }

--- a/src/main/java/com/api/pickle/domain/album/domain/SharingStatus.java
+++ b/src/main/java/com/api/pickle/domain/album/domain/SharingStatus.java
@@ -1,0 +1,13 @@
+package com.api.pickle.domain.album.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SharingStatus {
+    PRIVATE("PRIVATE"),
+    PUBLIC("PUBLIC");
+
+    private final String value;
+}

--- a/src/main/java/com/api/pickle/domain/album/dto/request/AlbumCreateRequest.java
+++ b/src/main/java/com/api/pickle/domain/album/dto/request/AlbumCreateRequest.java
@@ -1,0 +1,14 @@
+package com.api.pickle.domain.album.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumCreateRequest {
+    @Schema(description = "생성할 앨범의 이름")
+    private String name;
+}

--- a/src/main/java/com/api/pickle/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/api/pickle/domain/auth/application/JwtTokenService.java
@@ -9,6 +9,7 @@ import com.api.pickle.domain.member.domain.MemberRole;
 import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import com.api.pickle.global.util.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -48,9 +49,11 @@ public class JwtTokenService {
         SecurityContextHolder.getContext().setAuthentication(token);
     }
 
-    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) throws ExpiredJwtException{
         try {
             return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (ExpiredJwtException e) {
+            throw e;
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/com/api/pickle/domain/participant/dao/ParticipantRepository.java
+++ b/src/main/java/com/api/pickle/domain/participant/dao/ParticipantRepository.java
@@ -1,0 +1,7 @@
+package com.api.pickle.domain.participant.dao;
+
+import com.api.pickle.domain.participant.domain.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+}

--- a/src/main/java/com/api/pickle/domain/participant/domain/Bookmark.java
+++ b/src/main/java/com/api/pickle/domain/participant/domain/Bookmark.java
@@ -1,0 +1,13 @@
+package com.api.pickle.domain.participant.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Bookmark {
+    MARKED("MARKED"),
+    UNMARKED("UNMARKED");
+
+    private final String value;
+}

--- a/src/main/java/com/api/pickle/domain/participant/domain/Participant.java
+++ b/src/main/java/com/api/pickle/domain/participant/domain/Participant.java
@@ -4,6 +4,7 @@ import com.api.pickle.domain.album.domain.Album;
 import com.api.pickle.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,22 @@ public class Participant {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "album_id")
     private Album album;
+
+    @Enumerated(EnumType.STRING)
+    private Bookmark bookmark;
+
+    @Builder
+    public Participant(Album album, Member member, Bookmark bookmark){
+        this.album = album;
+        this.member = member;
+        this.bookmark = bookmark;
+    }
+
+    public static Participant createParticipant(Album album, Member member){
+        return Participant.builder()
+                .album(album)
+                .member(member)
+                .bookmark(Bookmark.UNMARKED)
+                .build();
+    }
 }

--- a/src/main/java/com/api/pickle/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/api/pickle/global/security/JwtAuthenticationFilter.java
@@ -2,6 +2,9 @@ package com.api.pickle.global.security;
 
 import com.api.pickle.domain.auth.application.JwtTokenService;
 import com.api.pickle.domain.auth.dto.AccessTokenDto;
+import com.api.pickle.global.error.exception.CustomException;
+import com.api.pickle.global.error.exception.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,9 +28,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
 
         if (accessTokenHeaderValue != null){
-            AccessTokenDto accessTokenDto = jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
-            if (accessTokenDto != null){
-                jwtTokenService.setAuthenticationToken(accessTokenDto.getMemberId(), accessTokenDto.getMemberRole());
+            try {
+                AccessTokenDto accessTokenDto = jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
+                if (accessTokenDto != null){
+                    jwtTokenService.setAuthenticationToken(accessTokenDto.getMemberId(), accessTokenDto.getMemberRole());
+                }
+            } catch (ExpiredJwtException e) {
+                throw new CustomException(ErrorCode.EXPIRED_JWT_TOKEN);
             }
         }
 


### PR DESCRIPTION
## 📌 Issue Number

- close #21 

## 🪐 작업 내용

- 앨범 생성 로직 구현

## ✅ PR 상세 내용

- 만료 토큰에 대한 예외 발생을 재구현 했습니다.
- `participant` 엔티티와 `album` 엔티티를 재구성했습니다.
   - `participant`의 경우 사용자의 북마크 상태를 적용하도록 enum을 추가했습니다.
   - `album`의 경우 공유 혹은 개인 앨범의 상태가 적용되도록 enum을 추가했습니다. 

## ❌ 애로 사항

- 아직 만료된 토큰에 대한 응답 설정이 완료되지 않았습니다. 

## 📚 Reference

- X
