### PR TITLE
feat: 공유 앨범 전환 로직 구현

### DIFF
--- a/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
+++ b/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
@@ -23,6 +23,6 @@ public class AlbumService {
         Album newAlbum = Album.createPrivateAlbum(albumName);
 
         albumRepository.save(newAlbum);
-        participantRepository.save(Participant.createParticipant(newAlbum, currentMember));
+        participantRepository.save(Participant.createHostParticipant(newAlbum, currentMember));
     }
 }

--- a/src/main/java/com/api/pickle/domain/album/domain/Album.java
+++ b/src/main/java/com/api/pickle/domain/album/domain/Album.java
@@ -1,6 +1,8 @@
 package com.api.pickle.domain.album.domain;
 
 import com.api.pickle.domain.common.model.BaseTimeEntity;
+import com.api.pickle.global.error.exception.CustomException;
+import com.api.pickle.global.error.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -34,5 +36,12 @@ public class Album extends BaseTimeEntity {
                 .name(name)
                 .status(SharingStatus.PRIVATE)
                 .build();
+    }
+
+    public void switchStatus(SharingStatus newStatus){
+        if (status == newStatus && newStatus == SharingStatus.PUBLIC){
+            throw new CustomException(ErrorCode.ALREADY_SHARED_ALBUM);
+        }
+        this.status = newStatus;
     }
 }

--- a/src/main/java/com/api/pickle/domain/participant/dao/ParticipantRepository.java
+++ b/src/main/java/com/api/pickle/domain/participant/dao/ParticipantRepository.java
@@ -1,7 +1,12 @@
 package com.api.pickle.domain.participant.dao;
 
+import com.api.pickle.domain.album.domain.Album;
+import com.api.pickle.domain.member.domain.Member;
 import com.api.pickle.domain.participant.domain.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+    Optional<Participant> findByMemberAndAlbum(Member member, Album album);
 }

--- a/src/main/java/com/api/pickle/domain/participant/domain/HostStatus.java
+++ b/src/main/java/com/api/pickle/domain/participant/domain/HostStatus.java
@@ -1,0 +1,13 @@
+package com.api.pickle.domain.participant.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum HostStatus {
+    HOST("HOST"),
+    GUEST("GUEST");
+
+    private final String value;
+}

--- a/src/main/java/com/api/pickle/domain/participant/domain/Participant.java
+++ b/src/main/java/com/api/pickle/domain/participant/domain/Participant.java
@@ -30,18 +30,32 @@ public class Participant {
     @Enumerated(EnumType.STRING)
     private Bookmark bookmark;
 
+    @Enumerated(EnumType.STRING)
+    private HostStatus hostStatus;
+
     @Builder
-    public Participant(Album album, Member member, Bookmark bookmark){
+    public Participant(Album album, Member member, Bookmark bookmark, HostStatus hostStatus){
         this.album = album;
         this.member = member;
         this.bookmark = bookmark;
+        this.hostStatus = hostStatus;
     }
 
-    public static Participant createParticipant(Album album, Member member){
+    public static Participant createHostParticipant(Album album, Member member){
         return Participant.builder()
                 .album(album)
                 .member(member)
                 .bookmark(Bookmark.UNMARKED)
+                .hostStatus(HostStatus.HOST)
+                .build();
+    }
+
+    public static Participant createGuestParticipant(Album album, Member member){
+        return Participant.builder()
+                .album(album)
+                .member(member)
+                .bookmark(Bookmark.UNMARKED)
+                .hostStatus(HostStatus.GUEST)
                 .build();
     }
 }

--- a/src/main/java/com/api/pickle/domain/sharedalbum/api/SharedAlbumController.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/api/SharedAlbumController.java
@@ -1,14 +1,12 @@
 package com.api.pickle.domain.sharedalbum.api;
 
+import com.api.pickle.domain.sharedalbum.dto.request.SwitchToSharedAlbumRequest;
 import com.api.pickle.domain.sharedalbum.dto.response.SharedLinkResponse;
 import com.api.pickle.domain.sharedalbum.application.SharedAlbumService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "공유 앨범 API", description = " 공유앨범 관련 API입니다.")
 @RestController
@@ -19,7 +17,8 @@ public class SharedAlbumController {
 
     @Operation(summary = "공유 앨범 전환", description = "공유 앨범으로 전환하고 공유 링크를 반환합니다.")
     @PostMapping("/{albumId}")
-    public SharedLinkResponse switchToPublicAlbum(@PathVariable Long albumId){
-        return sharedAlbumService.getSharedAlbumLink(albumId);
+    public SharedLinkResponse switchToPublicAlbum(@PathVariable Long albumId,
+                                                  @RequestBody SwitchToSharedAlbumRequest request){
+        return sharedAlbumService.getSharedAlbumLink(albumId, request.getAlbumPassword());
     }
 }

--- a/src/main/java/com/api/pickle/domain/sharedalbum/api/SharedAlbumController.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/api/SharedAlbumController.java
@@ -1,0 +1,25 @@
+package com.api.pickle.domain.sharedalbum.api;
+
+import com.api.pickle.domain.sharedalbum.dto.response.SharedLinkResponse;
+import com.api.pickle.domain.sharedalbum.application.SharedAlbumService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "공유 앨범 API", description = " 공유앨범 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/albums/share")
+public class SharedAlbumController {
+    private final SharedAlbumService sharedAlbumService;
+
+    @Operation(summary = "공유 앨범 전환", description = "공유 앨범으로 전환하고 공유 링크를 반환합니다.")
+    @PostMapping("/{albumId}")
+    public SharedLinkResponse switchToPublicAlbum(@PathVariable Long albumId){
+        return sharedAlbumService.getSharedAlbumLink(albumId);
+    }
+}

--- a/src/main/java/com/api/pickle/domain/sharedalbum/application/SharedAlbumService.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/application/SharedAlbumService.java
@@ -6,7 +6,6 @@ import com.api.pickle.domain.album.domain.SharingStatus;
 import com.api.pickle.domain.sharedalbum.dto.response.SharedLinkResponse;
 import com.api.pickle.domain.member.domain.Member;
 import com.api.pickle.domain.participant.dao.ParticipantRepository;
-import com.api.pickle.domain.participant.domain.Participant;
 import com.api.pickle.domain.sharedalbum.dao.SharedAlbumRepository;
 import com.api.pickle.domain.sharedalbum.domain.SharedAlbum;
 import com.api.pickle.global.error.exception.CustomException;
@@ -16,8 +15,6 @@ import com.api.pickle.global.util.RandomUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Transactional
 @Service
@@ -39,11 +36,9 @@ public class SharedAlbumService {
         return new SharedLinkResponse(saveSharedAlbum(album, password).getLink());
     }
 
-    private void validateAlbumOwner(Member member, Album album){
-        Optional<Participant> optionalParticipant = participantRepository.findByMemberAndAlbum(member, album);
-        if (optionalParticipant.isEmpty()){
-            throw new CustomException(ErrorCode.NOT_ALBUM_OWNER);
-        }
+    public void validateAlbumOwner(Member member, Album album){
+        participantRepository.findByMemberAndAlbum(member, album)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_ALBUM_OWNER));
     }
 
     private SharedAlbum saveSharedAlbum(Album album, String password) {

--- a/src/main/java/com/api/pickle/domain/sharedalbum/application/SharedAlbumService.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/application/SharedAlbumService.java
@@ -1,0 +1,57 @@
+package com.api.pickle.domain.sharedalbum.application;
+
+import com.api.pickle.domain.album.dao.AlbumRepository;
+import com.api.pickle.domain.album.domain.Album;
+import com.api.pickle.domain.album.domain.SharingStatus;
+import com.api.pickle.domain.sharedalbum.dto.response.SharedLinkResponse;
+import com.api.pickle.domain.member.domain.Member;
+import com.api.pickle.domain.participant.dao.ParticipantRepository;
+import com.api.pickle.domain.participant.domain.Participant;
+import com.api.pickle.domain.sharedalbum.dao.SharedAlbumRepository;
+import com.api.pickle.domain.sharedalbum.domain.SharedAlbum;
+import com.api.pickle.global.error.exception.CustomException;
+import com.api.pickle.global.error.exception.ErrorCode;
+import com.api.pickle.global.util.MemberUtil;
+import com.api.pickle.global.util.RandomUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class SharedAlbumService {
+    private final AlbumRepository albumRepository;
+    private final SharedAlbumRepository sharedAlbumRepository;
+    private final ParticipantRepository participantRepository;
+    private final MemberUtil memberUtil;
+
+    public SharedLinkResponse getSharedAlbumLink(Long albumId){
+        final Member currentMember = memberUtil.getCurrentMember();
+        Album album = albumRepository.findById(albumId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
+        album.switchStatus(SharingStatus.PUBLIC);
+
+        validateAlbumOwner(currentMember, album);
+
+        return new SharedLinkResponse(saveSharedAlbum(album).getLink());
+    }
+
+    private void validateAlbumOwner(Member member, Album album){
+        Optional<Participant> optionalParticipant = participantRepository.findByMemberAndAlbum(member, album);
+        if (optionalParticipant.isEmpty()){
+            throw new CustomException(ErrorCode.NOT_ALBUM_OWNER);
+        }
+    }
+
+    private SharedAlbum saveSharedAlbum(Album album) {
+        final int LINK_LENGTH = 30;
+        final int PASSWORD_LENGTH = 10;
+
+        String newLink = RandomUtil.generateToken(LINK_LENGTH);
+        String password = RandomUtil.generateToken(PASSWORD_LENGTH);
+        return sharedAlbumRepository.save(SharedAlbum.createSharedAlbum(album, newLink, password));
+    }
+}

--- a/src/main/java/com/api/pickle/domain/sharedalbum/application/SharedAlbumService.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/application/SharedAlbumService.java
@@ -28,7 +28,7 @@ public class SharedAlbumService {
     private final ParticipantRepository participantRepository;
     private final MemberUtil memberUtil;
 
-    public SharedLinkResponse getSharedAlbumLink(Long albumId){
+    public SharedLinkResponse getSharedAlbumLink(Long albumId, String password){
         final Member currentMember = memberUtil.getCurrentMember();
         Album album = albumRepository.findById(albumId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
@@ -36,7 +36,7 @@ public class SharedAlbumService {
 
         validateAlbumOwner(currentMember, album);
 
-        return new SharedLinkResponse(saveSharedAlbum(album).getLink());
+        return new SharedLinkResponse(saveSharedAlbum(album, password).getLink());
     }
 
     private void validateAlbumOwner(Member member, Album album){
@@ -46,12 +46,9 @@ public class SharedAlbumService {
         }
     }
 
-    private SharedAlbum saveSharedAlbum(Album album) {
+    private SharedAlbum saveSharedAlbum(Album album, String password) {
         final int LINK_LENGTH = 30;
-        final int PASSWORD_LENGTH = 10;
-
         String newLink = RandomUtil.generateToken(LINK_LENGTH);
-        String password = RandomUtil.generateToken(PASSWORD_LENGTH);
         return sharedAlbumRepository.save(SharedAlbum.createSharedAlbum(album, newLink, password));
     }
 }

--- a/src/main/java/com/api/pickle/domain/sharedalbum/dao/SharedAlbumRepository.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/dao/SharedAlbumRepository.java
@@ -1,0 +1,7 @@
+package com.api.pickle.domain.sharedalbum.dao;
+
+import com.api.pickle.domain.sharedalbum.domain.SharedAlbum;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SharedAlbumRepository extends JpaRepository<SharedAlbum, Long> {
+}

--- a/src/main/java/com/api/pickle/domain/sharedalbum/domain/SharedAlbum.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/domain/SharedAlbum.java
@@ -1,0 +1,44 @@
+package com.api.pickle.domain.sharedalbum.domain;
+
+import com.api.pickle.domain.album.domain.Album;
+import com.api.pickle.domain.common.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SharedAlbum extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shared_album_id")
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "album_id")
+    private Album album;
+
+    @Column(name = "album_link")
+    private String link;
+
+    @Column(name = "album_password")
+    private String password;
+
+    @Builder
+    public SharedAlbum(Album album, String link, String password){
+        this.album = album;
+        this.link = link;
+        this.password = password;
+    }
+
+    public static SharedAlbum createSharedAlbum(Album album, String link, String password){
+        return SharedAlbum.builder()
+                .album(album)
+                .link(link)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/api/pickle/domain/sharedalbum/dto/request/SwitchToSharedAlbumRequest.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/dto/request/SwitchToSharedAlbumRequest.java
@@ -1,0 +1,14 @@
+package com.api.pickle.domain.sharedalbum.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SwitchToSharedAlbumRequest {
+    @Schema(description = "공유 앨범의 비밀번호")
+    private String albumPassword;
+}

--- a/src/main/java/com/api/pickle/domain/sharedalbum/dto/response/SharedLinkResponse.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/dto/response/SharedLinkResponse.java
@@ -1,0 +1,13 @@
+package com.api.pickle.domain.sharedalbum.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SharedLinkResponse {
+    @Schema(description = "전환된 공유앨범의 공유 링크")
+    private final String link;
+}

--- a/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
@@ -21,6 +21,9 @@ public enum ErrorCode {
     MEMBER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
 
     ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 앨범을 찾을 수 없습니다"),
+    NOT_ALBUM_OWNER(HttpStatus.BAD_REQUEST, "해당 앨범의 소유자가 아닙니다."),
+
+    ALREADY_SHARED_ALBUM(HttpStatus.BAD_REQUEST, "이미 공유된 앨범입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/api/pickle/global/util/RandomUtil.java
+++ b/src/main/java/com/api/pickle/global/util/RandomUtil.java
@@ -1,0 +1,19 @@
+package com.api.pickle.global.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RandomUtil {
+    private static final SecureRandom secureRandom = new SecureRandom();
+    private static final Base64.Encoder base64Encoder = Base64.getUrlEncoder();
+
+    public static String generateToken(int length){
+        byte[] randomBytes = new byte[length];
+        secureRandom.nextBytes(randomBytes);
+        return base64Encoder.encodeToString(randomBytes);
+    }
+}


### PR DESCRIPTION
## 📌 Issue Number

- close #47 

## 🪐 작업 내용

- 공유 앨범 전환 로직 구현

## ✅ PR 상세 내용

- 공유 앨범으로의 전환 로직을 구현했습니다.
    - 해당 앨범 id가 존재하지 않으면 예외 발생
    - 전환 대상의 앨범이 이미 공유 앨범인 경우 예외 발생
    - 해당 앨범의 소유자가 아닐 시 예외 발생
- 공유 앨범에 대한 링크를 생성합니다.
    - `SecureRandom`을 사용한 `RandomUtil`을 생성하여 사용
- 앨범 생성 시 자동으로 `Participant`테이블이 `HOST` 상태가 되도록 변경하였습니다.
   - 이후 공유 앨범에 참여하게 되면 `GUEST`로 참여

## ❌ 애로 사항

- X

## 📚 Reference

- X
