### PR TITLE
chore: Spring Actuator 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 	// Mysql
 	implementation 'mysql:mysql-connector-java:8.0.33'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// Actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 jar {

--- a/src/main/java/com/api/pickle/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/api/pickle/global/config/security/WebSecurityConfig.java
@@ -25,9 +25,16 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception{
         defaultFilterChain(http);
-        http.authorizeHttpRequests((requests) -> requests.requestMatchers("**").permitAll())
-            .addFilterBefore(
-                    jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.authorizeHttpRequests(
+                requests ->
+                        requests.requestMatchers("**")
+                                .permitAll()
+                                .requestMatchers("/pickle-actuator/**")
+                                .permitAll());
+        
+        http.addFilterBefore(
+                jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,17 @@ spring:
       prod:
         - s3
         - security
+
+management:
+  endpoints:
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: health
+      base-path: /pickle-actuator
+  endpoint:
+    health:
+      enabled: true


### PR DESCRIPTION
## 📌 Issue Number

- close #54 

## 🪐 작업 내용

- Spring Actuator 추가

## ✅ PR 상세 내용

- /pickle-actuator/health로 헬스 체크를 할 수 있습니다.
- actuator 보안 설정을 추가하였습니다.
  - 기본적으로 모든 엔드포인트를 비활성화했습니다. (enabled-by-default)
  - health 엔드포인트만 활성화했습니다.
  - JMX 엔드포인트는 모두 비활성화하고, health 엔드포인트만 노출하도록 설정했습니다.
  - actuator 기본 경로를 /pickle-actuator/health로 변경하여 URI 스캔 공격을 방지할 수 있도록 했습니다.
- Spring Security에서 Actuator 엔드포인트에 대한 접근을 허용했습니다.

## 📸 스크린샷(선택)

- X

## ❌ 애로 사항

- X

## 📚 Reference

- https://techblog.woowahan.com/9232/
