### PR TITLE
feat: 앨범명 수정 로직 구현

### DIFF
--- a/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
+++ b/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
@@ -3,15 +3,14 @@ package com.api.pickle.domain.album.api;
 
 import com.api.pickle.domain.album.application.AlbumService;
 import com.api.pickle.domain.album.dto.request.AlbumCreateRequest;
+import com.api.pickle.domain.album.dto.request.UpdateAlbumRequest;
+import com.api.pickle.domain.album.dto.response.UpdateAlbumResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "앨범 API", description = "앨범 관련 API입니다.")
 @RestController
@@ -25,5 +24,12 @@ public class AlbumController {
     public ResponseEntity<Void> createAlbum(@RequestBody AlbumCreateRequest request){
         albumService.createAlbum(request.getName());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "앨범 명 수정", description = "앨범 명을 수정합니다.")
+    @PutMapping("/{albumId}")
+    public UpdateAlbumResponse updateAlbumName(@PathVariable Long albumId,
+                                               @RequestBody UpdateAlbumRequest request){
+        return albumService.updateAlbumName(albumId, request.getNewAlbumName());
     }
 }

--- a/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
+++ b/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
@@ -6,6 +6,7 @@ import com.api.pickle.domain.album.dto.response.UpdateAlbumResponse;
 import com.api.pickle.domain.member.domain.Member;
 import com.api.pickle.domain.participant.dao.ParticipantRepository;
 import com.api.pickle.domain.participant.domain.Participant;
+import com.api.pickle.domain.sharedalbum.application.SharedAlbumService;
 import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import com.api.pickle.global.util.MemberUtil;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlbumService {
     private final AlbumRepository albumRepository;
     private final ParticipantRepository participantRepository;
+    private final SharedAlbumService sharedAlbumService;
     private final MemberUtil memberUtil;
 
     public void createAlbum(String albumName){
@@ -33,12 +35,8 @@ public class AlbumService {
         final Member currentMember = memberUtil.getCurrentMember();
         Album album = albumRepository.findById(albumId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
-        validateAlbumOwner(currentMember, album);
+        sharedAlbumService.validateAlbumOwner(currentMember, album);
         album.updateAlbumName(newAlbumName);
         return new UpdateAlbumResponse(albumId, newAlbumName);
-    }
-
-    private void validateAlbumOwner(Member member, Album album){
-
     }
 }

--- a/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
+++ b/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
@@ -2,9 +2,12 @@ package com.api.pickle.domain.album.application;
 
 import com.api.pickle.domain.album.dao.AlbumRepository;
 import com.api.pickle.domain.album.domain.Album;
+import com.api.pickle.domain.album.dto.response.UpdateAlbumResponse;
 import com.api.pickle.domain.member.domain.Member;
 import com.api.pickle.domain.participant.dao.ParticipantRepository;
 import com.api.pickle.domain.participant.domain.Participant;
+import com.api.pickle.global.error.exception.CustomException;
+import com.api.pickle.global.error.exception.ErrorCode;
 import com.api.pickle.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,5 +27,18 @@ public class AlbumService {
 
         albumRepository.save(newAlbum);
         participantRepository.save(Participant.createHostParticipant(newAlbum, currentMember));
+    }
+
+    public UpdateAlbumResponse updateAlbumName(Long albumId, String newAlbumName){
+        final Member currentMember = memberUtil.getCurrentMember();
+        Album album = albumRepository.findById(albumId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
+        validateAlbumOwner(currentMember, album);
+        album.updateAlbumName(newAlbumName);
+        return new UpdateAlbumResponse(albumId, newAlbumName);
+    }
+
+    private void validateAlbumOwner(Member member, Album album){
+
     }
 }

--- a/src/main/java/com/api/pickle/domain/album/domain/Album.java
+++ b/src/main/java/com/api/pickle/domain/album/domain/Album.java
@@ -38,10 +38,14 @@ public class Album extends BaseTimeEntity {
                 .build();
     }
 
-    public void switchStatus(SharingStatus newStatus){
-        if (status == newStatus && newStatus == SharingStatus.PUBLIC){
+    public void switchStatus(SharingStatus newStatus) {
+        if (status == newStatus && newStatus == SharingStatus.PUBLIC) {
             throw new CustomException(ErrorCode.ALREADY_SHARED_ALBUM);
         }
         this.status = newStatus;
+    }
+
+    public void updateAlbumName(String newName){
+        this.name = newName;
     }
 }

--- a/src/main/java/com/api/pickle/domain/album/dto/request/UpdateAlbumRequest.java
+++ b/src/main/java/com/api/pickle/domain/album/dto/request/UpdateAlbumRequest.java
@@ -1,0 +1,16 @@
+package com.api.pickle.domain.album.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class UpdateAlbumRequest {
+    @Schema(description = "앨범의 수정될 이름")
+    private String newAlbumName;
+}

--- a/src/main/java/com/api/pickle/domain/album/dto/response/UpdateAlbumResponse.java
+++ b/src/main/java/com/api/pickle/domain/album/dto/response/UpdateAlbumResponse.java
@@ -1,0 +1,14 @@
+package com.api.pickle.domain.album.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateAlbumResponse {
+    @Schema(description = "수정된 앨범 id")
+    private Long albumId;
+    @Schema(description = "수정된 앨범의 이름")
+    private String updatedAlbumName;
+}


### PR DESCRIPTION
## 📌 Issue Number

- close #56 

## 🪐 작업 내용

- 앨범명 수정 로직 구현

## ✅ PR 상세 내용

- 앨범명과 수정할 앨범 id를 포함한 요청이 왔을 때 앨범 명을 수정합니다.
  - 해당 앨범의 소유자가 아닌 경우 예외 발생

## ❌ 애로 사항

- X

## 📚 Reference

- X
