### PR TITLE
feat: 공유 앨범 참여 api 구현

### DIFF
--- a/src/main/java/com/api/pickle/domain/sharedalbum/api/SharedAlbumController.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/api/SharedAlbumController.java
@@ -1,6 +1,8 @@
 package com.api.pickle.domain.sharedalbum.api;
 
+import com.api.pickle.domain.sharedalbum.dto.request.SharedAlbumParticipateRequest;
 import com.api.pickle.domain.sharedalbum.dto.request.SwitchToSharedAlbumRequest;
+import com.api.pickle.domain.sharedalbum.dto.response.SharedAlbumParticipateResponse;
 import com.api.pickle.domain.sharedalbum.dto.response.SharedLinkResponse;
 import com.api.pickle.domain.sharedalbum.application.SharedAlbumService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,5 +22,11 @@ public class SharedAlbumController {
     public SharedLinkResponse switchToPublicAlbum(@PathVariable Long albumId,
                                                   @RequestBody SwitchToSharedAlbumRequest request){
         return sharedAlbumService.getSharedAlbumLink(albumId, request.getAlbumPassword());
+    }
+
+    @Operation(summary = "공유 앨범 참여", description = "링크와 비밀번호를 통해 공유앨범에 참여합니다.")
+    @PostMapping("/participants")
+    public SharedAlbumParticipateResponse participateSharedAlbum(@RequestBody SharedAlbumParticipateRequest request){
+        return sharedAlbumService.participateSharedAlbum(request);
     }
 }

--- a/src/main/java/com/api/pickle/domain/sharedalbum/dao/SharedAlbumRepository.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/dao/SharedAlbumRepository.java
@@ -3,5 +3,8 @@ package com.api.pickle.domain.sharedalbum.dao;
 import com.api.pickle.domain.sharedalbum.domain.SharedAlbum;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SharedAlbumRepository extends JpaRepository<SharedAlbum, Long> {
+    Optional<SharedAlbum> findByLink(String Link);
 }

--- a/src/main/java/com/api/pickle/domain/sharedalbum/dto/request/SharedAlbumParticipateRequest.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/dto/request/SharedAlbumParticipateRequest.java
@@ -1,0 +1,16 @@
+package com.api.pickle.domain.sharedalbum.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SharedAlbumParticipateRequest {
+    @Schema(description = "공유 앨범의 링크")
+    private String albumLink;
+    @Schema(description = "공유 앨범의 비밀번호")
+    private String albumPassword;
+}

--- a/src/main/java/com/api/pickle/domain/sharedalbum/dto/response/SharedAlbumParticipateResponse.java
+++ b/src/main/java/com/api/pickle/domain/sharedalbum/dto/response/SharedAlbumParticipateResponse.java
@@ -1,0 +1,14 @@
+package com.api.pickle.domain.sharedalbum.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SharedAlbumParticipateResponse {
+    @Schema(description = "참여한 공유앨범의 id")
+    private Long albumId;
+    @Schema(description = "참여한 공유앨범의 이름")
+    private String albumName;
+}

--- a/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
@@ -23,7 +23,10 @@ public enum ErrorCode {
     ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 앨범을 찾을 수 없습니다"),
     NOT_ALBUM_OWNER(HttpStatus.BAD_REQUEST, "해당 앨범의 소유자가 아닙니다."),
 
-    ALREADY_SHARED_ALBUM(HttpStatus.BAD_REQUEST, "이미 공유된 앨범입니다.")
+    ALREADY_SHARED_ALBUM(HttpStatus.BAD_REQUEST, "이미 공유된 앨범입니다."),
+    SHARED_ALBUM_NOT_FOUND(HttpStatus.BAD_REQUEST, "공유 앨범을 찾을 수 없습니다."),
+    SHARED_ALBUM_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    MEMBER_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 참여한 앨범입니다.")
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 📌 Issue Number

- close #60 

## 🪐 작업 내용

- 공유 앨범 참여 api 구현

## ✅ PR 상세 내용

- 참여하려는 앨범의 링크와 비밀번호가 요청으로 들어오면 해당 공유 앨범에 참여합니다.
  - 참여하려는 링크가 존재하지 않는 경우 예외 발생
  - 참여하려는 공유 앨범의 링크와 비밀번호가 일치하지 않는 경우 예외 발생
  - 이미 참여한 공유앨범인 경우 예외 발생
- `GUEST`로 참여되도록 저장된 이후 참여한 앨범의 id와 이름을 반환합니다. 

## ❌ 애로 사항

- X

## 📚 Reference

- X