### PR TITLE
feat: 리프레시 토큰이 redis에서 동작되도록 수정

### DIFF
--- a/src/main/java/com/api/pickle/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/api/pickle/domain/auth/application/JwtTokenService.java
@@ -32,7 +32,11 @@ public class JwtTokenService {
 
     public String createRefreshToken(Long memberId) {
         String token = jwtUtil.generateRefreshToken(memberId);
-        RefreshToken refreshToken = RefreshToken.builder().memberId(memberId).token(token).build();
+        RefreshToken refreshToken = RefreshToken.builder()
+                .memberId(memberId)
+                .token(token)
+                .ttl(jwtUtil.getRefreshTokenExpirationTime())
+                .build();
         refreshTokenRepository.save(refreshToken);
         return token;
     }
@@ -67,7 +71,7 @@ public class JwtTokenService {
         RefreshToken refreshToken = refreshTokenRepository.findById(oldRefreshTokenDto.getMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSING_JWT_TOKEN));
         RefreshTokenDto refreshTokenDto = jwtUtil.generateRefreshTokenDto(refreshToken.getMemberId());
-        refreshToken.updateRefreshToken(refreshTokenDto.getToken());
+        refreshToken.updateRefreshToken(refreshTokenDto.getToken(), refreshTokenDto.getTtl());
         refreshTokenRepository.save(refreshToken);
         return refreshTokenDto;
     }

--- a/src/main/java/com/api/pickle/domain/auth/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/api/pickle/domain/auth/dao/RefreshTokenRepository.java
@@ -2,7 +2,5 @@ package com.api.pickle.domain.auth.dao;
 
 import com.api.pickle.domain.auth.domain.RefreshToken;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {}

--- a/src/main/java/com/api/pickle/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/api/pickle/domain/auth/domain/RefreshToken.java
@@ -1,28 +1,33 @@
 package com.api.pickle.domain.auth.domain;
 
-import com.api.pickle.domain.common.model.BaseTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import org.springframework.data.annotation.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 
-@Entity
 @Getter
 @NoArgsConstructor
-public class RefreshToken extends BaseTimeEntity {
+@RedisHash(value = "refreshToken")
+public class RefreshToken{
     @Id
     private Long memberId;
 
     private String token;
 
+    @TimeToLive
+    private long ttl;
+
     @Builder
-    public RefreshToken(Long memberId, String token) {
+    public RefreshToken(Long memberId, String token, long ttl) {
         this.memberId = memberId;
         this.token = token;
+        this.ttl = ttl;
     }
 
-    public void updateRefreshToken(String newToken){
+    public void updateRefreshToken(String newToken, long newTtl){
         this.token = newToken;
+        this.ttl = newTtl;
     }
 }

--- a/src/main/java/com/api/pickle/domain/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/com/api/pickle/domain/auth/dto/RefreshTokenDto.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class RefreshTokenDto {
     private Long memberId;
     private String token;
-    private Long expiredTime;
+    private Long ttl;
 }
 

--- a/src/main/java/com/api/pickle/global/util/JwtUtil.java
+++ b/src/main/java/com/api/pickle/global/util/JwtUtil.java
@@ -122,4 +122,8 @@ public class JwtUtil {
                 .build()
                 .parseClaimsJws(token);
     }
+
+    public long getRefreshTokenExpirationTime() {
+        return jwtProperties.getRefreshTokenExpirationTime();
+    }
 }


### PR DESCRIPTION
## 📌 Issue Number

- close #69 

## 🪐 작업 내용

- 리프레시 토큰이 레디스에서 사용되도록 수정

## ✅ PR 상세 내용

- 리프레시 토큰이 만료시간까지 레디스에 저장되도록 수정하였습니다.
  - `ttl` 사용
  - 일반 데이터베이스에는 저장되지 않음
- 토큰 재발급 시 리프레시토큰의 `ttl`또한 다시 설정되어 레디스의 `ttl`이 초기화됩니다.

## ❌ 애로 사항

- X

## 📚 Reference

- X
