### PR TITLE
chore: JaCoCo 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.5'
 	id 'io.spring.dependency-management' version '1.1.4'
+//	id 'jacoco'
 }
 
 group = 'com.api'
@@ -79,7 +80,82 @@ jar {
 
 tasks.named('test') {
 	useJUnitPlatform()
+//	finalizedBy 'jacocoTestReport'
 }
+
+//jacoco {
+//	toolVersion = "0.8.12"
+//}
+
+//def jacocoDir = layout.buildDirectory.dir("reports/")
+
+//def QDomains = []
+//for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+//	QDomains.add(qPattern + '*')
+//}
+
+//def jacocoExcludePatterns = [
+//		// 측정 안하고 싶은 패턴
+//		"**/*Application*",
+//		"**/*Config*",
+//		"**/*Exception*",
+//		"**/*Request*",
+//		"**/*Response*",
+//		"**/*Dto*",
+//		"**/*Interceptor*",
+//		"**/*Filter*",
+//		"**/*Resolver*",
+//]
+
+//jacocoTestCoverageVerification {
+//
+//	violationRules {
+//		rule {
+//			// rule 활성화
+//			enabled = true
+//
+//			// 클래스 단위로 룰 체크
+//			element = 'CLASS'
+//
+//			// 라인 커버리지를 최소 80% 만족
+//			limit {
+//				counter = 'LINE'
+//				value = 'COVEREDRATIO'
+//				minimum = 0.80
+//			}
+//
+//			// 브랜치 커버리지를 최소 80% 만족
+//			limit {
+//				counter = 'BRANCH'
+//				value = 'COVEREDRATIO'
+//				minimum = 0.80
+//			}
+//
+//			excludes = jacocoExcludePatterns + QDomains
+//		}
+//	}
+//}
+
+//jacocoTestReport {
+//	dependsOn test	// 테스트가 수행되어야만 report를 생성할 수 있도록 설정
+//	reports {
+//		html.required.set(true)
+//		xml.required.set(true)
+//		csv.required.set(true)
+//		html.destination jacocoDir.get().file("jacoco/index.html").asFile
+//		xml.destination jacocoDir.get().file("jacoco/index.xml").asFile
+//		csv.destination jacocoDir.get().file("jacoco/index.csv").asFile
+//	}
+//
+//	afterEvaluate {
+//		classDirectories.setFrom(
+//				files(classDirectories.files.collect {
+//					fileTree(dir: it, excludes: jacocoExcludePatterns + QDomains) // Querydsl 관련 제거
+//				})
+//		)
+//	}
+//	finalizedBy jacocoTestCoverageVerification
+//}
 
 def querydslDir = "$buildDir/generated/querydsl"
 

--- a/src/test/java/com/api/pickle/PickleApplicationTests.java
+++ b/src/test/java/com/api/pickle/PickleApplicationTests.java
@@ -1,9 +1,10 @@
 package com.api.pickle;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class PickleApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  config:
+    activate:
+      on-profile: "test"
+
+cloud:
+  aws:
+    region: ${AWS_REGION}
+    accessKey: ${AWS_ACCESS_KEY}
+    secretKey: ${AWS_SECRET_KEY}
+    bucket: ${AWS_BUCKET}
+    stack:
+      auto: false
+    endpoint: https://s3.ap-northeast-2.amazonaws.com


### PR DESCRIPTION
## 📌 Issue Number

- close #67 

## 🪐 작업 내용

- 테스트 코드 커버리지 측정을 위한 JaCoCo 설정

## ✅ PR 상세 내용

- Jacoco plugin 추가
- Jacoco 테스트 커버리지를 위한 rule인 JacocoTestCoverageVerification 추가
- JacocoTestReport 설정

## 📸 스크린샷(선택)

- X

## ❌ 애로 사항

- X

## 📚 Reference

- https://velog.io/@uiurihappy/Spring-Jacoco-Sonarcloud-로-코드-분석하기
