### PR TITLE
feat: 사용자 앨범 모두 조회 구현

### DIFF
--- a/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
+++ b/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
@@ -2,7 +2,6 @@ package com.api.pickle.domain.album.api;
 
 
 import com.api.pickle.domain.album.application.AlbumService;
-import com.api.pickle.domain.album.dao.AlbumRepository;
 import com.api.pickle.domain.album.dto.request.AlbumCreateRequest;
 import com.api.pickle.domain.album.dto.request.UpdateAlbumRequest;
 import com.api.pickle.domain.album.dto.response.AlbumSearchResponse;
@@ -51,5 +50,11 @@ public class AlbumController {
     public List<AlbumSearchResponse> searchAlbumStatus(@Parameter(description = "검색할 앨범의 공유상태", example = "PRIVATE OR PUBLIC")
                                                  @RequestParam String albumStatus) {
         return albumService.searchAlbumStatusInAlbumOrderByCreatedDateDesc(albumStatus);
+    }
+
+    @Operation(summary = "사용자 앨범 조회", description = "사용자가 참여 중인 모든 앨범을 조회합니다.")
+    @GetMapping("/list")
+    public List<AlbumSearchResponse> albumFindAll(){
+        return albumService.findAllAlbumOfMember();
     }
 }

--- a/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
+++ b/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
@@ -52,4 +52,9 @@ public class AlbumService {
     public List<AlbumSearchResponse> searchAlbumStatusInAlbumOrderByCreatedDateDesc(String albumStatus) {
         return albumRepository.searchAlbumStatusInAlbumOrderByCreatedDateDesc(albumStatus);
     }
+
+    public List<AlbumSearchResponse> findAllAlbumOfMember(){
+        final Member currentMember = memberUtil.getCurrentMember();
+        return albumRepository.findAllAlbumOfMemberByCreatedDateDesc(currentMember.getId());
+    }
 }

--- a/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryCustom.java
+++ b/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryCustom.java
@@ -8,4 +8,6 @@ public interface AlbumRepositoryCustom {
     List<AlbumSearchResponse> searchKeywordInAlbumOrderByCreatedDateDesc(String keyword);
 
     List<AlbumSearchResponse> searchAlbumStatusInAlbumOrderByCreatedDateDesc(String albumStatus);
+
+    List<AlbumSearchResponse> findAllAlbumOfMemberByCreatedDateDesc(Long memberId);
 }

--- a/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryImpl.java
+++ b/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.api.pickle.domain.album.dao;
 import com.api.pickle.domain.album.domain.SharingStatus;
 import com.api.pickle.domain.album.dto.response.AlbumSearchResponse;
 import com.api.pickle.domain.album.dto.response.QAlbumSearchResponse;
+import com.api.pickle.domain.participant.domain.QParticipant;
 import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -29,6 +30,24 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                 album.status.eq(SharingStatus.valueOf(albumStatus)),
                 ErrorCode.ALBUM_STATUS_NOT_FOUND
         );
+    }
+
+    @Override
+    public List<AlbumSearchResponse> findAllAlbumOfMemberByCreatedDateDesc(Long memberId) {
+        List<AlbumSearchResponse> results = queryFactory
+                .select(new QAlbumSearchResponse(
+                        album.id,
+                        album.name,
+                        album.status.stringValue()))
+                .from(QParticipant.participant)
+                .join(QParticipant.participant.album, album)
+                .where(QParticipant.participant.member.id.eq(memberId))
+                .orderBy(album.createdDate.desc())
+                .fetch();
+        if (results.isEmpty()){
+            throw new CustomException(ErrorCode.ALBUM_NOT_EXISTS);
+        }
+        return results;
     }
 
     private List<AlbumSearchResponse> searchAlbums(BooleanExpression condition, ErrorCode errorCode) {

--- a/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/api/pickle/global/error/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 
     ALBUM_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "검색어를 포함하는 앨범을 찾을 수 없습니다."),
     ALBUM_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상태의 앨범을 찾을 수 없습니다."),
+    ALBUM_NOT_EXISTS(HttpStatus.NOT_FOUND, "사용자의 앨범이 존재하지 않습니다."),
 
     SHARED_ALBUM_NOT_FOUND(HttpStatus.BAD_REQUEST, "공유 앨범을 찾을 수 없습니다."),
     SHARED_ALBUM_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),


### PR DESCRIPTION
## 📌 Issue Number

- close #74 

## 🪐 작업 내용

- 사용자 앨범 모두 조회 구현

## ✅ PR 상세 내용

- 사용자가 참여한 모든 앨범을 조회하도록 구현하였습니다.

## ❌ 애로 사항

- X

## 📚 Reference

- X