### PR TITLE
hotfix: ECS Task Definition에 AWS 자격 증명 추가하여 S3 접근이 가능하도록 수정

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -78,6 +78,14 @@
                 {
                     "name": "AWS_ENDPOINT",
                     "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:122971469363:secret:playauto/gmp-2dXhTZ:AWS_ENDPOINT::"
+                },
+                {
+                    "name": "AWS_ACCESS_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:122971469363:secret:playauto/gmp-2dXhTZ:AWS_ACCESS_KEY::"
+                },
+                {
+                    "name": "AWS_SECRET_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:122971469363:secret:playauto/gmp-2dXhTZ:AWS_SECRET_KEY::"
                 }
             ],
             "ulimits": [],


### PR DESCRIPTION
## 📌 Issue Number

- close #86 

## 🪐 작업 내용

- ECS Task Definition에 AWS 자격 증명을 추가하여 클라이언트에서 S3에 이미지 업로드가 가능하도록 긴급 수정하였습니다. 

## 📸 스크린샷(선택)

- X

## ❌ 애로 사항

- X

## 📚 Reference

- X
