### PR TITLE
feat: 앨범 목록 조회 및 검색 필터 적용 시 무한 스크롤 기능 구현

### DIFF
--- a/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
+++ b/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
@@ -10,6 +10,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -40,21 +45,26 @@ public class AlbumController {
 
     @Operation(summary = "앨범명 검색", description = "앨범명으로 검색하고 최신순으로 조회합니다.")
     @GetMapping("/search/keyword")
-    public List<AlbumSearchResponse> searchAlbumKeyword(@Parameter(description = "검색할 앨범의 이름 키워드", example = "앨범")
-                                                     @RequestParam String keyword) {
-        return albumService.searchKeywordInAlbumOrderByCreatedDateDesc(keyword);
+    public Slice<AlbumSearchResponse> searchAlbumKeyword(@Parameter(description = "검색할 앨범의 이름 키워드", example = "앨범")
+                                                         @RequestParam String keyword,
+                                                         @RequestParam(required = false) Long lastAlbumId,
+                                                         @RequestParam(value = "size", defaultValue = "1") int pageSize) {
+        return albumService.searchKeywordInAlbumOrderByCreatedDateDesc(keyword, pageSize, lastAlbumId);
     }
 
     @Operation(summary = "앨범상태 검색", description = "앨범상태로 검색하고 최신순으로 조회합니다.")
     @GetMapping("/search/status")
-    public List<AlbumSearchResponse> searchAlbumStatus(@Parameter(description = "검색할 앨범의 공유상태", example = "PRIVATE OR PUBLIC")
-                                                 @RequestParam String albumStatus) {
-        return albumService.searchAlbumStatusInAlbumOrderByCreatedDateDesc(albumStatus);
+    public Slice<AlbumSearchResponse> searchAlbumStatus(@Parameter(description = "검색할 앨범의 공유상태", example = "PRIVATE OR PUBLIC")
+                                                        @RequestParam String albumStatus,
+                                                        @RequestParam(required = false) Long lastAlbumId,
+                                                        @RequestParam(value = "size", defaultValue = "1") int pageSize) {
+        return albumService.searchAlbumStatusInAlbumOrderByCreatedDateDesc(albumStatus, pageSize, lastAlbumId);
     }
 
     @Operation(summary = "사용자 앨범 조회", description = "사용자가 참여 중인 모든 앨범을 조회합니다.")
     @GetMapping("/list")
-    public List<AlbumSearchResponse> albumFindAll(){
-        return albumService.findAllAlbumOfMember();
+    public Slice<AlbumSearchResponse> albumFindAll(@RequestParam(required = false) Long lastAlbumId,
+                                                   @RequestParam(value = "size", defaultValue = "1") int pageSize) {
+        return albumService.findAllAlbumOfMember(pageSize, lastAlbumId);
     }
 }

--- a/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
+++ b/src/main/java/com/api/pickle/domain/album/api/AlbumController.java
@@ -47,8 +47,11 @@ public class AlbumController {
     @GetMapping("/search/keyword")
     public Slice<AlbumSearchResponse> searchAlbumKeyword(@Parameter(description = "검색할 앨범의 이름 키워드", example = "앨범")
                                                          @RequestParam String keyword,
+                                                         @Parameter(description = "이전 페이지의 마지막 앨범 ID (첫 페이지는 비워두세요.)")
                                                          @RequestParam(required = false) Long lastAlbumId,
-                                                         @RequestParam(value = "size", defaultValue = "1") int pageSize) {
+                                                         @Parameter(description = "페이지당 앨범 수", example = "1")
+                                                         @RequestParam(value = "size") int pageSize) {
+
         return albumService.searchKeywordInAlbumOrderByCreatedDateDesc(keyword, pageSize, lastAlbumId);
     }
 
@@ -56,15 +59,21 @@ public class AlbumController {
     @GetMapping("/search/status")
     public Slice<AlbumSearchResponse> searchAlbumStatus(@Parameter(description = "검색할 앨범의 공유상태", example = "PRIVATE OR PUBLIC")
                                                         @RequestParam String albumStatus,
+                                                        @Parameter(description = "이전 페이지의 마지막 앨범 ID (첫 페이지는 비워두세요.)")
                                                         @RequestParam(required = false) Long lastAlbumId,
-                                                        @RequestParam(value = "size", defaultValue = "1") int pageSize) {
+                                                        @Parameter(description = "페이지당 앨범 수", example = "1")
+                                                        @RequestParam(value = "size") int pageSize) {
+
         return albumService.searchAlbumStatusInAlbumOrderByCreatedDateDesc(albumStatus, pageSize, lastAlbumId);
     }
 
     @Operation(summary = "사용자 앨범 조회", description = "사용자가 참여 중인 모든 앨범을 조회합니다.")
     @GetMapping("/list")
-    public Slice<AlbumSearchResponse> albumFindAll(@RequestParam(required = false) Long lastAlbumId,
-                                                   @RequestParam(value = "size", defaultValue = "1") int pageSize) {
+    public Slice<AlbumSearchResponse> albumFindAll(@Parameter(description = "이전 페이지의 마지막 앨범 ID (첫 페이지는 비워두세요.)")
+                                                   @RequestParam(required = false) Long lastAlbumId,
+                                                   @Parameter(description = "페이지당 앨범 수", example = "1")
+                                                   @RequestParam(value = "size") int pageSize) {
+
         return albumService.findAllAlbumOfMember(pageSize, lastAlbumId);
     }
 }

--- a/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
+++ b/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
@@ -12,6 +12,8 @@ import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import com.api.pickle.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,18 +47,18 @@ public class AlbumService {
         return new UpdateAlbumResponse(albumId, newAlbumName);
     }
 
-    public List<AlbumSearchResponse> searchKeywordInAlbumOrderByCreatedDateDesc(String keyword) {
+    public Slice<AlbumSearchResponse> searchKeywordInAlbumOrderByCreatedDateDesc(String keyword, int pageSize, Long lastAlbumId) {
         final Member currentMember = memberUtil.getCurrentMember();
-        return albumRepository.searchKeywordInAlbumOrderByCreatedDateDesc(currentMember.getId(), keyword);
+        return albumRepository.searchKeywordInAlbumOrderByCreatedDateDesc(currentMember.getId(), keyword, pageSize, lastAlbumId);
     }
 
-    public List<AlbumSearchResponse> searchAlbumStatusInAlbumOrderByCreatedDateDesc(String albumStatus) {
+    public Slice<AlbumSearchResponse> searchAlbumStatusInAlbumOrderByCreatedDateDesc(String albumStatus, int pageSize, Long lastAlbumId) {
         final Member currentMember = memberUtil.getCurrentMember();
-        return albumRepository.searchAlbumStatusInAlbumOrderByCreatedDateDesc(currentMember.getId(), albumStatus);
+        return albumRepository.searchAlbumStatusInAlbumOrderByCreatedDateDesc(currentMember.getId(), albumStatus, pageSize, lastAlbumId);
     }
 
-    public List<AlbumSearchResponse> findAllAlbumOfMember(){
+    public Slice<AlbumSearchResponse> findAllAlbumOfMember(int pageSize, Long lastAlbumId) {
         final Member currentMember = memberUtil.getCurrentMember();
-        return albumRepository.findAllAlbumOfMemberByCreatedDateDesc(currentMember.getId());
+        return albumRepository.findAllAlbumOfMemberByCreatedDateDesc(currentMember.getId(), pageSize, lastAlbumId);
     }
 }

--- a/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryCustom.java
+++ b/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryCustom.java
@@ -1,13 +1,15 @@
 package com.api.pickle.domain.album.dao;
 import com.api.pickle.domain.album.dto.response.AlbumSearchResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 public interface AlbumRepositoryCustom {
 
-    List<AlbumSearchResponse> searchKeywordInAlbumOrderByCreatedDateDesc(Long memberId, String keyword);
+    Slice<AlbumSearchResponse> searchKeywordInAlbumOrderByCreatedDateDesc(Long memberId, String keyword, int pageSize, Long lastAlbumId);
 
-    List<AlbumSearchResponse> searchAlbumStatusInAlbumOrderByCreatedDateDesc(Long memberId, String albumStatus);
+    Slice<AlbumSearchResponse> searchAlbumStatusInAlbumOrderByCreatedDateDesc(Long memberId, String albumStatus, int pageSize, Long lastAlbumId);
 
-    List<AlbumSearchResponse> findAllAlbumOfMemberByCreatedDateDesc(Long memberId);
+    Slice<AlbumSearchResponse> findAllAlbumOfMemberByCreatedDateDesc(Long memberId, int pageSize, Long lastAlbumId);
 }

--- a/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryImpl.java
+++ b/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryImpl.java
@@ -6,8 +6,14 @@ import com.api.pickle.domain.participant.domain.QParticipant;
 import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
 import java.util.List;
 import static com.api.pickle.domain.album.domain.QAlbum.album;
 
@@ -17,33 +23,39 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<AlbumSearchResponse> searchKeywordInAlbumOrderByCreatedDateDesc(Long memberId, String keyword) {
+    public Slice<AlbumSearchResponse> searchKeywordInAlbumOrderByCreatedDateDesc(Long memberId, String keyword, int pageSize, Long lastAlbumId) {
         return albumsFilter(
                 memberId,
                 album.name.containsIgnoreCase(keyword),
-                ErrorCode.ALBUM_KEYWORD_NOT_FOUND
+                ErrorCode.ALBUM_KEYWORD_NOT_FOUND,
+                pageSize,
+                lastAlbumId
         );
     }
 
     @Override
-    public List<AlbumSearchResponse> searchAlbumStatusInAlbumOrderByCreatedDateDesc(Long memberId, String albumStatus) {
+    public Slice<AlbumSearchResponse> searchAlbumStatusInAlbumOrderByCreatedDateDesc(Long memberId, String albumStatus, int pageSize, Long lastAlbumId) {
         return albumsFilter(
                 memberId,
                 album.status.eq(SharingStatus.valueOf(albumStatus)),
-                ErrorCode.ALBUM_STATUS_NOT_FOUND
+                ErrorCode.ALBUM_STATUS_NOT_FOUND,
+                pageSize,
+                lastAlbumId
         );
     }
 
     @Override
-    public List<AlbumSearchResponse> findAllAlbumOfMemberByCreatedDateDesc(Long memberId) {
+    public Slice<AlbumSearchResponse> findAllAlbumOfMemberByCreatedDateDesc(Long memberId, int pageSize, Long lastAlbumId) {
         return albumsFilter(
                 memberId,
                 null,
-                ErrorCode.ALBUM_NOT_EXISTS
+                ErrorCode.ALBUM_NOT_EXISTS,
+                pageSize,
+                lastAlbumId
         );
     }
 
-    private List<AlbumSearchResponse> albumsFilter(Long memberId, BooleanExpression condition, ErrorCode errorCode) {
+    private Slice<AlbumSearchResponse> albumsFilter(Long memberId, BooleanExpression condition, ErrorCode errorCode, int pageSize, Long lastAlbumId) {
         List<AlbumSearchResponse> results = queryFactory
                 .select(new QAlbumSearchResponse(
                         album.id,
@@ -51,14 +63,37 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                         album.status.stringValue()))
                 .from(QParticipant.participant)
                 .join(QParticipant.participant.album, album)
-                .where(QParticipant.participant.member.id.eq(memberId). and(condition))
+                .where(
+                        lastAlbumId(lastAlbumId),
+                        QParticipant.participant.member.id.eq(memberId). and(condition))
                 .orderBy(album.createdDate.desc())
+                .limit(pageSize + 1)
                 .fetch();
 
         if (results.isEmpty()) {
             throw new CustomException(errorCode);
         }
 
-        return results;
+        return checkLastPage(pageSize, results);
+    }
+
+    private BooleanExpression lastAlbumId(Long albumId) {
+        if (albumId == null) {
+            return null;
+        }
+
+        return album.id.lt(albumId);
+    }
+
+    private Slice<AlbumSearchResponse> checkLastPage(int pageSize, List<AlbumSearchResponse> results) {
+
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
     }
 }


### PR DESCRIPTION
## 📌 Issue Number

- close #89 

## 🪐 작업 내용

- 앨범 목록 조회 및 검색 필터 적용 시 무한 스크롤이 가능하도록 구현하였습니다.

## ✅ PR 상세 내용

- 프론트 측에서 넘어온 lastAlbumId를 통해 그 이후의 데이터만 검색하도록 하여, 전체 row를 검색함으로써 나타나는 성능 저하를 방지하였습니다.
- 초기 요청시에는 albumId가 없으므로 null을 반환하여, orderBy를 통해 정렬된 데이터 중, 가장 최근의 데이터를 반환하도록 구현하였습니다.

## 📸 스크린샷(선택)

- X

## ❌ 애로 사항

- X

## 📚 Reference

- X
