### PR TITLE
fix: 앨범 조회 및 검색에 앨범의 북마크 상태가 추가되도록 수정

### DIFF
--- a/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryImpl.java
+++ b/src/main/java/com/api/pickle/domain/album/dao/AlbumRepositoryImpl.java
@@ -2,20 +2,19 @@ package com.api.pickle.domain.album.dao;
 import com.api.pickle.domain.album.domain.SharingStatus;
 import com.api.pickle.domain.album.dto.response.AlbumSearchResponse;
 import com.api.pickle.domain.album.dto.response.QAlbumSearchResponse;
-import com.api.pickle.domain.participant.domain.QParticipant;
 import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 import static com.api.pickle.domain.album.domain.QAlbum.album;
+import static com.api.pickle.domain.bookmark.domain.QBookmark.bookmark;
+import static com.api.pickle.domain.participant.domain.QParticipant.participant;
 
 @RequiredArgsConstructor
 public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
@@ -60,12 +59,14 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                 .select(new QAlbumSearchResponse(
                         album.id,
                         album.name,
-                        album.status.stringValue()))
-                .from(QParticipant.participant)
-                .join(QParticipant.participant.album, album)
+                        album.status.stringValue(),
+                        bookmark.markStatus.stringValue()))
+                .from(participant)
+                .join(participant.album, album)
+                .join(bookmark).on(participant.eq(bookmark.participant))
                 .where(
                         lastAlbumId(lastAlbumId),
-                        QParticipant.participant.member.id.eq(memberId). and(condition))
+                        participant.member.id.eq(memberId). and(condition))
                 .orderBy(album.createdDate.desc())
                 .limit(pageSize + 1)
                 .fetch();

--- a/src/main/java/com/api/pickle/domain/album/dto/response/AlbumSearchResponse.java
+++ b/src/main/java/com/api/pickle/domain/album/dto/response/AlbumSearchResponse.java
@@ -18,10 +18,14 @@ public class AlbumSearchResponse {
     @Schema(description = "검색된 앨범의 상태")
     private String searchedAlbumStatus;
 
+    @Schema(description = "검색된 앨범의 북마크 상태")
+    private String searchedAlbumMarkedStatus;
+
     @QueryProjection
-    public AlbumSearchResponse(Long albumId, String searchedAlbumName, String searchedAlbumStatus) {
+    public AlbumSearchResponse(Long albumId, String searchedAlbumName, String searchedAlbumStatus, String searchedAlbumMarkedStatus) {
         this.albumId = albumId;
         this.searchedAlbumName = searchedAlbumName;
         this.searchedAlbumStatus = searchedAlbumStatus;
+        this.searchedAlbumMarkedStatus = searchedAlbumMarkedStatus;
     }
 }

--- a/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryImpl.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryImpl.java
@@ -37,7 +37,8 @@ public class BookmarkRepositoryImpl implements BookmarkRepositoryCustom{
                 .select(new QAlbumSearchResponse(
                         album.id,
                         album.name,
-                        album.status.stringValue()
+                        album.status.stringValue(),
+                        bookmark.markStatus.stringValue()
                 ))
                 .from(bookmark)
                 .join(bookmark.participant, participant)


### PR DESCRIPTION
## 📌 Issue Number

- close #94 

## 🪐 작업 내용

- 앨범 조회 및 검색에 앨범의 북마크 상태가 추가되도록 수정

## ✅ PR 상세 내용

- 앨범 조회 및 검색에 앨범의 북마크 상태가 추가되도록 수정하였습니다. 

## ❌ 애로 사항

- X

## 📚 Reference

- X
