### PR TITLE
hotfix: 앨범 조회 및 검색 시 redis 데이터가 반영되지 않는 부분 수정

### DIFF
--- a/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
+++ b/src/main/java/com/api/pickle/domain/album/application/AlbumService.java
@@ -13,12 +13,9 @@ import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import com.api.pickle.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -54,16 +51,19 @@ public class AlbumService {
 
     public Slice<AlbumSearchResponse> searchKeywordInAlbumOrderByCreatedDateDesc(String keyword, int pageSize, Long lastAlbumId) {
         final Member currentMember = memberUtil.getCurrentMember();
-        return albumRepository.searchKeywordInAlbumOrderByCreatedDateDesc(currentMember.getId(), keyword, pageSize, lastAlbumId);
+        Slice<AlbumSearchResponse> response =  albumRepository.searchKeywordInAlbumOrderByCreatedDateDesc(currentMember.getId(), keyword, pageSize, lastAlbumId);
+        return bookmarkService.reflectRedisMarkStatus(response, currentMember.getId());
     }
 
     public Slice<AlbumSearchResponse> searchAlbumStatusInAlbumOrderByCreatedDateDesc(String albumStatus, int pageSize, Long lastAlbumId) {
         final Member currentMember = memberUtil.getCurrentMember();
-        return albumRepository.searchAlbumStatusInAlbumOrderByCreatedDateDesc(currentMember.getId(), albumStatus, pageSize, lastAlbumId);
+        Slice<AlbumSearchResponse> response =  albumRepository.searchAlbumStatusInAlbumOrderByCreatedDateDesc(currentMember.getId(), albumStatus, pageSize, lastAlbumId);
+        return bookmarkService.reflectRedisMarkStatus(response, currentMember.getId());
     }
 
     public Slice<AlbumSearchResponse> findAllAlbumOfMember(int pageSize, Long lastAlbumId) {
         final Member currentMember = memberUtil.getCurrentMember();
-        return albumRepository.findAllAlbumOfMemberByCreatedDateDesc(currentMember.getId(), pageSize, lastAlbumId);
+        Slice<AlbumSearchResponse> response =  albumRepository.findAllAlbumOfMemberByCreatedDateDesc(currentMember.getId(), pageSize, lastAlbumId);
+        return bookmarkService.reflectRedisMarkStatus(response, currentMember.getId());
     }
 }

--- a/src/main/java/com/api/pickle/domain/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/application/BookmarkService.java
@@ -56,16 +56,29 @@ public class BookmarkService {
 
         Slice<AlbumSearchResponse> searchResponses = bookmarkRepository.findAlbumByBookmarks(currentMember.getId(), markedLists, pageSize, lastAlbumId);
 
-        searchResponses.getContent().forEach(
-                albumSearchResponse -> {
-                    if (markedSet.contains(albumSearchResponse.getAlbumId())){
-                        albumSearchResponse.setSearchedAlbumMarkedStatus(MarkStatus.MARKED.getValue());
-                    } else if (unmarkedSet.contains(albumSearchResponse.getAlbumId())){
-                        albumSearchResponse.setSearchedAlbumMarkedStatus(MarkStatus.UNMARKED.getValue());
-                    }
-                });
+        updateMarkedStatus(searchResponses, markedSet, unmarkedSet);
 
         return searchResponses;
+    }
+
+    public Slice<AlbumSearchResponse> reflectRedisMarkStatus (Slice<AlbumSearchResponse> response, Long userId){
+        RedisBookmarkStatusDto markedLists = getRedisBookmarkDataOfUser(userId);
+        Set<Long> markedSet = new HashSet<>(markedLists.getMarkedList());
+        Set<Long> unmarkedSet = new HashSet<>(markedLists.getUnmarkedList());
+
+        updateMarkedStatus(response, markedSet, unmarkedSet);
+
+        return response;
+    }
+
+    public void updateMarkedStatus(Slice<AlbumSearchResponse> searchResponses, Set<Long> markedSet, Set<Long> unmarkedSet) {
+        searchResponses.getContent().forEach(albumSearchResponse -> {
+            if (markedSet.contains(albumSearchResponse.getAlbumId())) {
+                albumSearchResponse.setSearchedAlbumMarkedStatus(MarkStatus.MARKED.getValue());
+            } else if (unmarkedSet.contains(albumSearchResponse.getAlbumId())) {
+                albumSearchResponse.setSearchedAlbumMarkedStatus(MarkStatus.UNMARKED.getValue());
+            }
+        });
     }
 
     private RedisBookmarkStatusDto getRedisBookmarkDataOfUser(Long userId) {

--- a/src/main/java/com/api/pickle/domain/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/application/BookmarkService.java
@@ -87,16 +87,16 @@ public class BookmarkService {
         List<Long> markedIds = new ArrayList<>();
         List<Long> unmarkedIds = new ArrayList<>();
 
-        for (Map.Entry<Object, Object> entry : redisData.entrySet()){
-            Long bookmarkId = Long.parseLong(entry.getKey().toString());
-            MarkStatus markStatus = MarkStatus.valueOf(entry.getValue().toString());
+        redisData.forEach((key, value) -> {
+            Long bookmarkId = Long.parseLong(key.toString());
+            MarkStatus markStatus = MarkStatus.valueOf(value.toString());
 
             if (markStatus == MarkStatus.MARKED){
                 markedIds.add(bookmarkId);
             } else if (markStatus == MarkStatus.UNMARKED){
                 unmarkedIds.add(bookmarkId);
             }
-        }
+        });
 
         return new RedisBookmarkStatusDto(markedIds, unmarkedIds);
     }

--- a/src/main/java/com/api/pickle/domain/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/application/BookmarkService.java
@@ -61,8 +61,8 @@ public class BookmarkService {
         return searchResponses;
     }
 
-    public Slice<AlbumSearchResponse> reflectRedisMarkStatus (Slice<AlbumSearchResponse> response, Long userId){
-        RedisBookmarkStatusDto markedLists = getRedisBookmarkDataOfUser(userId);
+    public Slice<AlbumSearchResponse> reflectRedisMarkStatus (Slice<AlbumSearchResponse> response, Long memberId){
+        RedisBookmarkStatusDto markedLists = getRedisBookmarkDataOfUser(memberId);
         Set<Long> markedSet = new HashSet<>(markedLists.getMarkedList());
         Set<Long> unmarkedSet = new HashSet<>(markedLists.getUnmarkedList());
 
@@ -81,8 +81,8 @@ public class BookmarkService {
         });
     }
 
-    private RedisBookmarkStatusDto getRedisBookmarkDataOfUser(Long userId) {
-        Map<Object, Object> redisData = redisService.getHash(concatKeyAndUserId(userId));
+    private RedisBookmarkStatusDto getRedisBookmarkDataOfUser(Long memberId) {
+        Map<Object, Object> redisData = redisService.getHash(concatKeyAndMemberId(memberId));
 
         List<Long> markedIds = new ArrayList<>();
         List<Long> unmarkedIds = new ArrayList<>();
@@ -101,14 +101,14 @@ public class BookmarkService {
         return new RedisBookmarkStatusDto(markedIds, unmarkedIds);
     }
 
-    private String concatKeyAndUserId(Long userId){
-        return BOOKMARK_USER_ID_KEY.concat(userId.toString());
+    private String concatKeyAndMemberId(Long memberId){
+        return BOOKMARK_MEMBER_ID_KEY.concat(memberId.toString());
     }
 
     private void markAlbumOfMember(Participant participant, MarkStatus status) {
         Bookmark bookmark = bookmarkRepository.findByParticipant(participant)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOOKMARK_NOT_FOUND));
-        redisService.putToBookmarkHash(generateRedisKey(BOOKMARK_USER_ID_KEY, participant.getMember().getId()),
+        redisService.putToBookmarkHash(generateRedisKey(BOOKMARK_MEMBER_ID_KEY, participant.getMember().getId()),
                 bookmark.getId().toString(),
                 status);
     }

--- a/src/main/java/com/api/pickle/domain/bookmark/application/RedisDatabaseSyncService.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/application/RedisDatabaseSyncService.java
@@ -29,10 +29,10 @@ public class RedisDatabaseSyncService {
     @Scheduled(fixedRate = DATABASE_SYNC_CYCLE)
     @Transactional
     public void syncRedsToDatabase(){
-        Set<String> userIds = redisService.getKeysByPattern(generateBookmarkWildcard());
+        Set<String> memberIds = redisService.getKeysByPattern(generateBookmarkWildcard());
 
-        for (String stringedUserId : userIds){
-            Map<Object, Object> hash = redisService.getHash(stringedUserId);
+        for (String stringedMemberId : memberIds){
+            Map<Object, Object> hash = redisService.getHash(stringedMemberId);
             for (Map.Entry<Object, Object> entry : hash.entrySet()){
                 Long bookmarkId = Long.parseLong(entry.getKey().toString());
                 Bookmark bookmark = bookmarkRepository.findById(bookmarkId)
@@ -46,6 +46,6 @@ public class RedisDatabaseSyncService {
     }
 
     private String generateBookmarkWildcard(){
-        return BOOKMARK_USER_ID_KEY.concat(WILD_CARD);
+        return BOOKMARK_MEMBER_ID_KEY.concat(WILD_CARD);
     }
 }

--- a/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryCustom.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryCustom.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Slice;
 
 public interface BookmarkRepositoryCustom {
 
-    Slice<AlbumSearchResponse> findAlbumByBookmarks(Long userId, RedisBookmarkStatusDto markLists, int pageSize, Long lastAlbumId);
+    Slice<AlbumSearchResponse> findAlbumByBookmarks(Long memberId, RedisBookmarkStatusDto markLists, int pageSize, Long lastAlbumId);
 }

--- a/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryCustom.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryCustom.java
@@ -1,13 +1,11 @@
 package com.api.pickle.domain.bookmark.dao;
 
 import com.api.pickle.domain.album.dto.response.AlbumSearchResponse;
-import com.api.pickle.domain.bookmark.domain.Bookmark;
+import com.api.pickle.domain.bookmark.dto.RedisBookmarkStatusDto;
 import org.springframework.data.domain.Slice;
 
-import java.util.List;
 
 public interface BookmarkRepositoryCustom {
-    List<Bookmark> findAllByMemberId (Long memberId);
 
-    Slice<AlbumSearchResponse> findAlbumByBookmarks(List<Bookmark> bookmarks, int pageSize, Long lastAlbumId);
+    Slice<AlbumSearchResponse> findAlbumByBookmarks(Long userId, RedisBookmarkStatusDto markLists, int pageSize, Long lastAlbumId);
 }

--- a/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryImpl.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryImpl.java
@@ -24,7 +24,7 @@ public class BookmarkRepositoryImpl implements BookmarkRepositoryCustom{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<AlbumSearchResponse> findAlbumByBookmarks(Long userId, RedisBookmarkStatusDto markLists, int pageSize, Long lastAlbumId){
+    public Slice<AlbumSearchResponse> findAlbumByBookmarks(Long memberId, RedisBookmarkStatusDto markLists, int pageSize, Long lastAlbumId){
         BooleanExpression markedCondition = bookmark.markStatus.eq(MarkStatus.MARKED);
         BooleanExpression inMarkedListCondition = bookmark.id.in(markLists.getMarkedList());
         BooleanExpression notInMarkedListCondition = bookmark.id.notIn(markLists.getUnmarkedList());
@@ -39,7 +39,7 @@ public class BookmarkRepositoryImpl implements BookmarkRepositoryCustom{
                 .from(bookmark)
                 .join(bookmark.participant, participant)
                 .join(participant.album, album)
-                .where(participant.member.id.eq(userId),
+                .where(participant.member.id.eq(memberId),
                         markedCondition.or(inMarkedListCondition),
                         notInMarkedListCondition,
                         lastAlbumId(lastAlbumId))

--- a/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryImpl.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/dao/BookmarkRepositoryImpl.java
@@ -2,7 +2,8 @@ package com.api.pickle.domain.bookmark.dao;
 
 import com.api.pickle.domain.album.dto.response.AlbumSearchResponse;
 import com.api.pickle.domain.album.dto.response.QAlbumSearchResponse;
-import com.api.pickle.domain.bookmark.domain.Bookmark;
+import com.api.pickle.domain.bookmark.domain.MarkStatus;
+import com.api.pickle.domain.bookmark.dto.RedisBookmarkStatusDto;
 import com.api.pickle.global.error.exception.CustomException;
 import com.api.pickle.global.error.exception.ErrorCode;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -23,16 +24,11 @@ public class BookmarkRepositoryImpl implements BookmarkRepositoryCustom{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Bookmark> findAllByMemberId(Long memberId){
-        return queryFactory
-                .selectFrom(bookmark)
-                .join(bookmark.participant, participant)
-                .where(participant.member.id.eq(memberId))
-                .fetch();
-    }
+    public Slice<AlbumSearchResponse> findAlbumByBookmarks(Long userId, RedisBookmarkStatusDto markLists, int pageSize, Long lastAlbumId){
+        BooleanExpression markedCondition = bookmark.markStatus.eq(MarkStatus.MARKED);
+        BooleanExpression inMarkedListCondition = bookmark.id.in(markLists.getMarkedList());
+        BooleanExpression notInMarkedListCondition = bookmark.id.notIn(markLists.getUnmarkedList());
 
-    @Override
-    public Slice<AlbumSearchResponse> findAlbumByBookmarks(List<Bookmark> bookmarks, int pageSize, Long lastAlbumId){
         List<AlbumSearchResponse> results =  queryFactory
                 .select(new QAlbumSearchResponse(
                         album.id,
@@ -43,10 +39,14 @@ public class BookmarkRepositoryImpl implements BookmarkRepositoryCustom{
                 .from(bookmark)
                 .join(bookmark.participant, participant)
                 .join(participant.album, album)
-                .where(bookmark.in(bookmarks), lastAlbumId(lastAlbumId))
+                .where(participant.member.id.eq(userId),
+                        markedCondition.or(inMarkedListCondition),
+                        notInMarkedListCondition,
+                        lastAlbumId(lastAlbumId))
                 .orderBy(album.createdDate.desc())
                 .limit(pageSize + 1)
                 .fetch();
+
         if (results.isEmpty()) {
             throw new CustomException(ErrorCode.BOOKMARKED_ALBUM_NOT_FOUND);
         }

--- a/src/main/java/com/api/pickle/domain/bookmark/dto/RedisBookmarkStatusDto.java
+++ b/src/main/java/com/api/pickle/domain/bookmark/dto/RedisBookmarkStatusDto.java
@@ -1,0 +1,13 @@
+package com.api.pickle.domain.bookmark.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class RedisBookmarkStatusDto {
+    private List<Long> markedList;
+    private List<Long> unmarkedList;
+}

--- a/src/main/java/com/api/pickle/global/common/constants/RedisConstants.java
+++ b/src/main/java/com/api/pickle/global/common/constants/RedisConstants.java
@@ -1,7 +1,7 @@
 package com.api.pickle.global.common.constants;
 
 public final class RedisConstants {
-    public static final String BOOKMARK_USER_ID_KEY = "bookmark:user:";
+    public static final String BOOKMARK_MEMBER_ID_KEY = "bookmark:user:";
     public static final String WILD_CARD = "*";
 
     public static final int DATABASE_SYNC_CYCLE = 3600000; // 1h


### PR DESCRIPTION
## 📌 Issue Number

- close #99 

## 🪐 작업 내용

- 앨범 조회 및 검색 시 redis 데이터가 반영되지 않는 부분 수정

## ✅ PR 상세 내용

- 즐겨찾기 앨범 조회 로직을 수정하였습니다.
  - 레디스 데이터를 조회하여 북마크가 적용된 데이터와 해제된 데이터를 분리하고 이를 querydsl로 조회 시 반영되도록 수정
- 사용자 앨범 조회, 앨범 상태로 조회, 앨범명으로 검색 조회 로직을 수정하였습니다.
  - 조회된 데이터에 대하여 레디스의 데이터로 갱신한 뒤 반환되도록 수정

## ❌ 애로 사항

- X

## 📚 Reference

- X
